### PR TITLE
Re-authenticate when online token expires

### DIFF
--- a/hooks/useShopifyMutation.js
+++ b/hooks/useShopifyMutation.js
@@ -1,20 +1,41 @@
 import { getSessionToken } from '@shopify/app-bridge-utils'
 import { useAppBridge } from '@shopify/app-bridge-react'
+import { Redirect } from '@shopify/app-bridge/actions'
 import { useMutation } from 'react-query'
-import { request } from 'graphql-request'
+import { rawRequest } from 'graphql-request'
 
 export const useShopifyMutation = (query) => {
   const app = useAppBridge()
 
-  const {mutateAsync, ...mutationProps} = useMutation(async (variables) => {
-    const sessionToken = await getSessionToken(app)
-    const headers = new Headers({})
+  const {mutateAsync, ...mutationProps} = useMutation(
+    async (variables) => {
+      const sessionToken = await getSessionToken(app)
+      const headers = new Headers({})
 
-    headers.append('Authorization', `Bearer ${sessionToken}`)
-    headers.append('X-Requested-With', 'XMLHttpRequest')
-    const response = await request('/api/graphql', query, variables, headers)
-    return response
-  })
+      headers.append('Authorization', `Bearer ${sessionToken}`)
+      headers.append('X-Requested-With', 'XMLHttpRequest')
+      const response = await rawRequest('/api/graphql', query, variables, headers)
+      checkHeadersForReauthorization(response.headers, app)
+
+      return response
+    }, 
+    {
+      onError: (result) => {
+        const {response} = result
+        checkHeadersForReauthorization(response.headers, app)
+      },
+    },
+  )
 
   return [mutateAsync, mutationProps]
+}
+
+
+const checkHeadersForReauthorization = (headers, app) => {
+  if (headers.get('X-Shopify-API-Request-Failure-Reauthorize') === '1') {
+    const authUrlHeader = headers.get('X-Shopify-API-Request-Failure-Reauthorize-Url')
+
+    const redirect = Redirect.create(app)
+    redirect.dispatch(Redirect.Action.APP, authUrlHeader || `/api/auth`)
+  }
 }

--- a/hooks/useShopifyQuery.js
+++ b/hooks/useShopifyQuery.js
@@ -1,18 +1,39 @@
 import { getSessionToken } from '@shopify/app-bridge-utils'
 import { useAppBridge } from '@shopify/app-bridge-react'
+import { Redirect } from '@shopify/app-bridge/actions'
 import { useQuery } from 'react-query'
-import { request } from 'graphql-request'
+import { rawRequest } from 'graphql-request'
 
 export const useShopifyQuery = (key, query) => {
   const app = useAppBridge()
 
-  return useQuery(key, async (variables) => {
-    const sessionToken = await getSessionToken(app)
-    const headers = new Headers({})
+  return useQuery(
+    key, 
+    async (variables) => {
+      const sessionToken = await getSessionToken(app)
+      const headers = new Headers({})
 
-    headers.append('Authorization', `Bearer ${sessionToken}`)
-    headers.append('X-Requested-With', 'XMLHttpRequest')
-    const response = await request('/api/graphql', query, variables, headers)
-    return response
-  })
+      headers.append('Authorization', `Bearer ${sessionToken}`)
+      headers.append('X-Requested-With', 'XMLHttpRequest')
+      const response = await rawRequest('/api/graphql', query, variables, headers)
+      checkHeadersForReauthorization(response.headers, app)
+
+      return response
+    },
+    {
+      onError: (result) => {
+        const {response} = result
+        checkHeadersForReauthorization(response.headers, app)
+      },
+    }
+  )
+}
+
+const checkHeadersForReauthorization = (headers, app) => {
+  if (headers.get('X-Shopify-API-Request-Failure-Reauthorize') === '1') {
+    const authUrlHeader = headers.get('X-Shopify-API-Request-Failure-Reauthorize-Url')
+
+    const redirect = Redirect.create(app)
+    redirect.dispatch(Redirect.Action.APP, authUrlHeader || `/api/auth`)
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/first-party-library-planning/issues/209
This is a follow up to https://github.com/Shopify/starter-react-frontend-app/pull/12

### WHAT is this pull request doing?

Applying the same re-auth logic as the authenticatedFetch does.

### 🎩 Instructions

Add an endpoint to `home/backend/index.js` to delete the stored online-token:
```js
  app.get('/api/kill-session', verifyRequest(app), async (req, res) => {
    const session = await Shopify.Utils.deleteCurrentSession(req, res)

    res.status(200).send({success: true})
  })
```

Add a button to the UI that hits this endpoint. (I added it to the ProductsCard since it had all the imports and functions I needed.

```jsx
  async function killSession() {
    const {success} = await fetch('/api/kill-session').then((res) => res.json())
    return success
  }
  
  const handleKillSession = () => {
    killSession().then((s) => console.log(s))
  }

  return (
    <Button primary loading={isLoading} onClick={handleKillSession}>
      Kill Session
    </Button>
  )
```

Load the app. Click the kill Session button and then try to populate products. 

The page should redirect to the auth dance. 

![Re-auth PR](https://user-images.githubusercontent.com/390744/164077186-06fcabe1-ecc0-42ba-8760-f3e8c3fc4a8e.gif)

