### PR TITLE
Import path.  I removed this when rebasing, which was a mistake

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import path from "path";
 
 // prettier-ignore
 const INDEX_ROUTE = "^/(\\?.*)?$";


### PR DESCRIPTION
I removed this when rebasing a branch, but as we use the dependency this is needed.