### PR TITLE
[Feature] Add NavigationMenu and App Bridge routing

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,30 +1,26 @@
-import { BrowserRouter } from "react-router-dom";
-import { Provider as AppBridgeProvider } from "@shopify/app-bridge-react";
-import { AppProvider as PolarisProvider } from "@shopify/polaris";
-import translations from "@shopify/polaris/locales/en.json";
-import "@shopify/polaris/build/esm/styles.css";
-import { GraphQLProvider } from "./components/providers/GraphQLProvider";
+import { BrowserRouter } from 'react-router-dom'
+import { AppProvider as PolarisProvider } from '@shopify/polaris'
+import translations from '@shopify/polaris/locales/en.json'
+import '@shopify/polaris/build/esm/styles.css'
 
-import Routes from "./Routes";
+import { TitleBarSection } from './components/TitleBarSection'
+import { AppBridgeProvider } from './components/providers/AppBridgeProvider'
+import { GraphQLProvider } from './components/providers/GraphQLProvider'
+import Routes from './Routes'
 
 export default function App() {
   const pages = import.meta.globEager("./pages/**/*.[jt](s|sx)");
 
   return (
     <PolarisProvider i18n={translations}>
-      <AppBridgeProvider
-        config={{
-          apiKey: process.env.SHOPIFY_API_KEY,
-          host: new URL(location).searchParams.get("host"),
-          forceRedirect: true,
-        }}
-      >
-        <GraphQLProvider>
-          <BrowserRouter>
+      <BrowserRouter>
+        <AppBridgeProvider>
+          <GraphQLProvider>
+            <TitleBarSection />
             <Routes pages={pages} />
-          </BrowserRouter>
-        </GraphQLProvider>
-      </AppBridgeProvider>
+          </GraphQLProvider>
+        </AppBridgeProvider>
+      </BrowserRouter>
     </PolarisProvider>
-  );
+  )
 }

--- a/Routes.jsx
+++ b/Routes.jsx
@@ -7,21 +7,21 @@ export default function Routes({ pages }) {
   const routes = useRoutes(pages);
   const routeComponents = routes.map(({ path, component: Component }) => (
     <Route key={path} path={path} element={<Component />} />
-  ));
+  ))
 
-  return <ReactRouterRoutes>{routeComponents}</ReactRouterRoutes>;
+  return <ReactRouterRoutes>{routeComponents}</ReactRouterRoutes>
 }
 
 function useRoutes(pages) {
   const routes = Object.keys(pages)
     .map((key) => {
       let path = key
-        .replace("./pages", "")
-        .replace(/\.(t|j)sx?$/, "")
+        .replace('./pages', '')
+        .replace(/\.(t|j)sx?$/, '')
         /**
          * Replace /index with /
          */
-        .replace(/\/index$/i, "/")
+        .replace(/\/index$/i, '/')
         /**
          * Only lowercase the first letter. This allows the developer to use camelCase
          * dynamic paths while ensuring their standard routes are normalized to lowercase.
@@ -30,22 +30,22 @@ function useRoutes(pages) {
         /**
          * Convert /[handle].jsx and /[...handle].jsx to /:handle.jsx for react-router-dom
          */
-        .replace(/\[(?:[.]{3})?(\w+?)\]/g, (_match, param) => `:${param}`);
+        .replace(/\[(?:[.]{3})?(\w+?)\]/g, (_match, param) => `:${param}`)
 
-      if (path.endsWith("/") && path !== "/") {
-        path = path.substring(0, path.length - 1);
+      if (path.endsWith('/') && path !== '/') {
+        path = path.substring(0, path.length - 1)
       }
 
       if (!pages[key].default) {
-        console.warn(`${key} doesn't export a default React component`);
+        console.warn(`${key} doesn't export a default React component`)
       }
 
       return {
         path,
         component: pages[key].default,
-      };
+      }
     })
-    .filter((route) => route.component);
+    .filter((route) => route.component)
 
-  return routes;
+  return routes
 }

--- a/components/TitleBarSection.jsx
+++ b/components/TitleBarSection.jsx
@@ -1,0 +1,45 @@
+import { NavigationMenu, TitleBar } from '@shopify/app-bridge-react'
+import { useLocation } from 'react-router-dom'
+
+export function TitleBarSection() {
+  const { pathname } = useLocation()
+  const showButtons = pathname === '/tab2'
+
+  return (
+    <>
+      <TitleBar
+        title="App Name"
+        primaryAction={
+          showButtons
+            ? {
+                content: 'Primary action',
+                onAction: () => console.log('Primary action'),
+              }
+            : null
+        }
+        secondaryActions={
+          showButtons
+            ? [
+                {
+                  content: 'Secondary action',
+                  onAction: () => console.log('Secondary action'),
+                },
+              ]
+            : []
+        }
+      />
+      <NavigationMenu
+        navigationLinks={[
+          {
+            label: 'Tab 1',
+            destination: '/',
+          },
+          {
+            label: 'Tab 2',
+            destination: '/tab2',
+          },
+        ]}
+      />
+    </>
+  )
+}

--- a/components/providers/AppBridgeProvider.jsx
+++ b/components/providers/AppBridgeProvider.jsx
@@ -1,0 +1,38 @@
+import { useMemo, useRef } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { Provider } from '@shopify/app-bridge-react'
+
+export function AppBridgeProvider({ children }) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const history = useMemo(
+    () => ({
+      replace: (path) => {
+        navigate(path, { replace: true })
+      },
+    }),
+    [navigate]
+  )
+
+  const routerConfig = useMemo(
+    () => ({ history, location }),
+    [history, location]
+  )
+
+  const { current: host } = useRef(
+    new URL(window.location).searchParams.get('host')
+  )
+
+  return (
+    <Provider
+      config={{
+        apiKey: process.env.SHOPIFY_API_KEY,
+        host,
+        forceRedirect: true,
+      }}
+      router={routerConfig}
+    >
+      {children}
+    </Provider>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "node": ">= 12.16"
   },
   "dependencies": {
-    "@shopify/app-bridge": "^2.0.19",
-    "@shopify/app-bridge-react": "^2.0.19",
-    "@shopify/app-bridge-utils": "^2.0.19",
+    "@shopify/app-bridge": "^2.0.25",
+    "@shopify/app-bridge-react": "^2.0.25",
+    "@shopify/app-bridge-utils": "^2.0.25",
     "@shopify/polaris": "^9.2.2",
     "@vitejs/plugin-react": "1.2.0",
     "cross-env": "^7.0.3",
@@ -35,5 +35,11 @@
     "prettier": "^2.6.0",
     "vi-fetch": "^0.6.1",
     "vitest": "^0.10.0"
-  }
+  },
+  "prettier": {
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": false,
+    "singleQuote": true
+  } 
 }

--- a/pages/tab2.jsx
+++ b/pages/tab2.jsx
@@ -1,0 +1,32 @@
+import { Card, Page, Layout, TextContainer, Heading } from '@shopify/polaris'
+
+export default function Tab2() {
+  return (
+    <Page fullWidth>
+      <Layout>
+        <Layout.Section>
+          <Card sectioned>
+            <Heading>Heading</Heading>
+            <TextContainer>
+              <p>Body</p>
+            </TextContainer>
+          </Card>
+          <Card sectioned>
+            <Heading>Heading</Heading>
+            <TextContainer>
+              <p>Body</p>
+            </TextContainer>
+          </Card>
+        </Layout.Section>
+        <Layout.Section secondary>
+          <Card sectioned>
+            <Heading>Heading</Heading>
+            <TextContainer>
+              <p>Body</p>
+            </TextContainer>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </Page>
+  )
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/first-party-library-planning/issues/161

- Template requires routing features from App Bridge to prevent hard reload of iframe and to keep parent window url in sync
- `NavigationMenu` required

### WHAT is this pull request doing?

https://user-images.githubusercontent.com/7654369/165380045-41315823-d70f-4b52-9482-5e11a45d1839.mov

- Add `router` prop to App Bridge Provider 
  - This required some shuffling around of the component and provider hierarchy, as the `Provider`'s `router` prop requires is a `location` and `navigation` from `react-router-dom`, which must be used within a `Router` component.
- Add NavigationMenu with required tabs
- Add *temporary* prettier config -- we can remove it when we're done working on the template

Known issue: On first navigation there is a full page reload and a slow render. This doesn't seem to be related to App Bridge functionality because subsequent navigation between tabs works smoothly. I'm not sure if this has something to with the build, but I will reach out for help and either address it in this PR or another one. 

## 🎩  Instructions

In shopify-cli-next, 
- Change the ngrok auth token in `packages/app/src/cli/services/dev/tunnel.ts` to your own 
- Run `yarn build:affected && yarn create-app --template=https://github.com/Shopify/starter-node-app#test-ab-features --local --name=test_app`
- `cd test_app`
- `yarn dev`
- Click `ngrok` link to open app
- Test that navigation behavior works and matches [figma](https://www.figma.com/file/13VXYtW2vOltT8mD35K7uF/App-Template-and-Sample-App?node-id=0%3A1)
