### PR TITLE
Allow non-app auth requests

### DIFF
--- a/hooks/useAuthenticatedFetch.js
+++ b/hooks/useAuthenticatedFetch.js
@@ -1,22 +1,28 @@
-import {authenticatedFetch} from '@shopify/app-bridge-utils'
-import {Redirect} from '@shopify/app-bridge/actions'
-import {useAppBridge} from '@shopify/app-bridge-react'
+import { authenticatedFetch } from "@shopify/app-bridge-utils";
+import { useAppBridge } from "@shopify/app-bridge-react";
+import { Redirect } from "@shopify/app-bridge/actions";
 
 export function useAuthenticatedFetch() {
-  const app = useAppBridge()
-  const fetchFunction = authenticatedFetch(app)
+  const app = useAppBridge();
+  const fetchFunction = authenticatedFetch(app);
 
   return async (uri, options) => {
-    const response = await fetchFunction(uri, options)
+    const response = await fetchFunction(uri, options);
+    checkHeadersForReauthorization(response.headers, app);
+    return response;
+  };
+}
 
-    if (response.headers.get('X-Shopify-API-Request-Failure-Reauthorize') === '1') {
-      const authUrlHeader = response.headers.get('X-Shopify-API-Request-Failure-Reauthorize-Url')
+function checkHeadersForReauthorization(headers, app) {
+  if (headers.get("X-Shopify-API-Request-Failure-Reauthorize") === "1") {
+    const authUrlHeader =
+      headers.get("X-Shopify-API-Request-Failure-Reauthorize-Url") ||
+      `/api/auth`;
 
-      const redirect = Redirect.create(app)
-      redirect.dispatch(Redirect.Action.APP, authUrlHeader || `/api/auth`)
-      return null
-    }
-
-    return response
+    const redirect = Redirect.create(app);
+    const redirectType = authUrlHeader.startsWith("/")
+      ? Redirect.Action.APP
+      : Redirect.Action.REMOTE;
+    redirect.dispatch(redirectType, authUrlHeader);
   }
 }

--- a/hooks/useShopifyMutation.js
+++ b/hooks/useShopifyMutation.js
@@ -1,41 +1,17 @@
-import { getSessionToken } from '@shopify/app-bridge-utils'
-import { useAppBridge } from '@shopify/app-bridge-react'
-import { Redirect } from '@shopify/app-bridge/actions'
-import { useMutation } from 'react-query'
-import { rawRequest } from 'graphql-request'
+import { useMutation } from "react-query";
+import { GraphQLClient } from "graphql-request";
+
+import { useAuthenticatedFetch } from "./useAuthenticatedFetch.js";
 
 export const useShopifyMutation = (query) => {
-  const app = useAppBridge()
+  const authenticatedFetch = useAuthenticatedFetch();
+  const graphQLClient = new GraphQLClient("/api/graphql", {
+    fetch: authenticatedFetch,
+  });
 
-  const {mutateAsync, ...mutationProps} = useMutation(
-    async (variables) => {
-      const sessionToken = await getSessionToken(app)
-      const headers = new Headers({})
+  const { mutateAsync, ...mutationProps } = useMutation(async (variables) =>
+    graphQLClient.rawRequest(query, variables)
+  );
 
-      headers.append('Authorization', `Bearer ${sessionToken}`)
-      headers.append('X-Requested-With', 'XMLHttpRequest')
-      const response = await rawRequest('/api/graphql', query, variables, headers)
-      checkHeadersForReauthorization(response.headers, app)
-
-      return response
-    }, 
-    {
-      onError: (result) => {
-        const {response} = result
-        checkHeadersForReauthorization(response.headers, app)
-      },
-    },
-  )
-
-  return [mutateAsync, mutationProps]
-}
-
-
-const checkHeadersForReauthorization = (headers, app) => {
-  if (headers.get('X-Shopify-API-Request-Failure-Reauthorize') === '1') {
-    const authUrlHeader = headers.get('X-Shopify-API-Request-Failure-Reauthorize-Url')
-
-    const redirect = Redirect.create(app)
-    redirect.dispatch(Redirect.Action.APP, authUrlHeader || `/api/auth`)
-  }
-}
+  return [mutateAsync, mutationProps];
+};

--- a/hooks/useShopifyQuery.js
+++ b/hooks/useShopifyQuery.js
@@ -1,39 +1,13 @@
-import { getSessionToken } from '@shopify/app-bridge-utils'
-import { useAppBridge } from '@shopify/app-bridge-react'
-import { Redirect } from '@shopify/app-bridge/actions'
-import { useQuery } from 'react-query'
-import { rawRequest } from 'graphql-request'
+import { useQuery } from "react-query";
+import { GraphQLClient } from "graphql-request";
+
+import { useAuthenticatedFetch } from "./useAuthenticatedFetch.js";
 
 export const useShopifyQuery = (key, query) => {
-  const app = useAppBridge()
+  const authenticatedFetch = useAuthenticatedFetch();
+  const graphQLClient = new GraphQLClient("/api/graphql", {
+    fetch: authenticatedFetch,
+  });
 
-  return useQuery(
-    key, 
-    async (variables) => {
-      const sessionToken = await getSessionToken(app)
-      const headers = new Headers({})
-
-      headers.append('Authorization', `Bearer ${sessionToken}`)
-      headers.append('X-Requested-With', 'XMLHttpRequest')
-      const response = await rawRequest('/api/graphql', query, variables, headers)
-      checkHeadersForReauthorization(response.headers, app)
-
-      return response
-    },
-    {
-      onError: (result) => {
-        const {response} = result
-        checkHeadersForReauthorization(response.headers, app)
-      },
-    }
-  )
-}
-
-const checkHeadersForReauthorization = (headers, app) => {
-  if (headers.get('X-Shopify-API-Request-Failure-Reauthorize') === '1') {
-    const authUrlHeader = headers.get('X-Shopify-API-Request-Failure-Reauthorize-Url')
-
-    const redirect = Redirect.create(app)
-    redirect.dispatch(Redirect.Action.APP, authUrlHeader || `/api/auth`)
-  }
-}
+  return useQuery(key, async () => graphQLClient.rawRequest(query));
+};


### PR DESCRIPTION
### WHY are these changes introduced?

Once we add billing to the template, we may need to be able to break out of the admin to go to the billing confirmation. Currently, we. are always using an `APP` redirect action, which won't work for an external address.

### WHAT is this pull request doing?

Changing the `useAuthenticatedFetch` hook to check if the path to go to begins with `/` and making it a remote redirect if it does not.

Also, I noticed we could change the query / mutation hooks to build on top of that one to centralize the code for handling the headers, rather than manually getting the session token and checking the headers.