### PR TITLE
Changes frontend submodule repo name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "starter-react-frontend-app",
+  "name": "shopify-frontend-template-react",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
### WHY are these changes introduced?

In preparation to launch new Node app template, the repo name for the frontend repo is being changed to `shopify-frontend-template-react`

Relates to Shopify/first-party-library-planning#307
Aligns with Shopify/starter-node-app#30

NB: not to be merged until IT rename ticket completed

### WHAT is this pull request doing?

☝🏻 See above!