### PR TITLE
Rename home to web

### DIFF
--- a/shopify.web.toml
+++ b/shopify.web.toml
@@ -2,3 +2,4 @@ type="frontend"
 
 [commands]
 dev = "npm run dev"
+build = "npm run build"


### PR DESCRIPTION
This is renaming the `home.toml` file to `web.toml` file to match the updated requirements for the CLI.