### PR TITLE
Chore: Add index files and hooks alias

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -3,9 +3,8 @@ import { AppProvider as PolarisProvider } from '@shopify/polaris'
 import translations from '@shopify/polaris/locales/en.json'
 import '@shopify/polaris/build/esm/styles.css'
 
-import { TitleBarSection } from './components/TitleBarSection'
-import { AppBridgeProvider } from './components/providers/AppBridgeProvider'
-import { GraphQLProvider } from './components/providers/GraphQLProvider'
+import { AppBridgeProvider, GraphQLProvider, TitleBarSection } from 'components'
+
 import Routes from './Routes'
 
 export default function App() {

--- a/components/ProductsCard.jsx
+++ b/components/ProductsCard.jsx
@@ -10,8 +10,7 @@ import {
 import { Toast } from '@shopify/app-bridge-react'
 import { gql } from 'graphql-request'
 
-import { useShopifyMutation } from '../hooks/useShopifyMutation'
-import { useAuthenticatedFetch } from '../hooks/useAuthenticatedFetch'
+import { useAuthenticatedFetch, useShopifyMutation } from 'hooks'
 
 const PRODUCTS_QUERY = gql`
   mutation populateProduct($input: ProductInput!) {

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,0 +1,3 @@
+export { ProductsCard } from './ProductsCard'
+export { TitleBarSection } from './TitleBarSection'
+export * from './providers'

--- a/components/providers/index.ts
+++ b/components/providers/index.ts
@@ -1,0 +1,2 @@
+export { AppBridgeProvider } from './AppBridgeProvider'
+export { GraphQLProvider } from './GraphQLProvider'

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -1,0 +1,3 @@
+export { useAuthenticatedFetch } from './useAuthenticatedFetch'
+export { useShopifyMutation } from './useShopifyMutation'
+export { useShopifyQuery } from './useShopifyQuery'

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,33 +1,34 @@
-import { defineConfig } from "vite";
-import path from "path";
+import { defineConfig } from 'vite'
+import path from 'path'
 
 // prettier-ignore
 const INDEX_ROUTE = "^/(\\?.*)?$";
-const API_ROUTE = "^/api/";
+const API_ROUTE = '^/api/'
 
-const root = new URL(".", import.meta.url).pathname;
+const root = new URL('.', import.meta.url).pathname
 export default defineConfig({
   root,
   define: {
-    "process.env.SHOPIFY_API_KEY": JSON.stringify(process.env.SHOPIFY_API_KEY),
+    'process.env.SHOPIFY_API_KEY': JSON.stringify(process.env.SHOPIFY_API_KEY),
   },
   esbuild: {
     jsxInject: `import React from 'react'`,
   },
   resolve: {
     alias: {
-      assets: path.resolve(root, "./assets"),
-      components: path.resolve(root, "./components"),
-      pages: path.resolve(root, "./pages"),
-      test: path.resolve(root, "./test"),
+      assets: path.resolve(root, './assets'),
+      components: path.resolve(root, './components'),
+      hooks: path.resolve(root, './hooks'),
+      pages: path.resolve(root, './pages'),
+      test: path.resolve(root, './test'),
     },
   },
   server: {
     port: process.env.FRONTEND_PORT,
-    middlewareMode: "html",
+    middlewareMode: 'html',
     hmr: {
-      protocol: "ws",
-      host: "localhost",
+      protocol: 'ws',
+      host: 'localhost',
       port: 64999,
       clientPort: 64999,
     },
@@ -48,10 +49,10 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: "jsdom",
-    setupFiles: "./test/setup.js",
+    environment: 'jsdom',
+    setupFiles: './test/setup.js',
     deps: {
-      inline: ["@shopify/react-testing"],
+      inline: ['@shopify/react-testing'],
     },
   },
-});
+})


### PR DESCRIPTION
Closes https://github.com/Shopify/first-party-library-planning/issues/239
Closes https://github.com/Shopify/first-party-library-planning/issues/240

### WHY are these changes introduced?

After working with this template in the QR Codes project, the team recognized that index files could be useful. We also missed adding a path alias for "hooks"

### WHAT is this pull request doing?

- Add index files for `hooks`, `providers`, and `components` directories (simplifies importing when using more than one of these elements in a file)
- Add alias for `hooks` import


## Testing

- Clone and `cd` into `shopify-cli-next`
- Run the following command to generate an app using this template
  ```
  yarn build:affected && yarn create-app --template=https://github.com/Shopify/starter-node-app#elana-test-branch --local --name=test_app
  ```
- Run `cd test-app`
- Run `yarn dev --tunnel`

The app should load with no errors and no changes.