### PR TITLE
feat: add empty state page

### DIFF
--- a/Routes.jsx
+++ b/Routes.jsx
@@ -9,7 +9,12 @@ export default function Routes({ pages }) {
     <Route key={path} path={path} element={<Component />} />
   ))
 
-  return <ReactRouterRoutes>{routeComponents}</ReactRouterRoutes>
+  return (
+    <ReactRouterRoutes>
+      {routeComponents}
+      <Route path="*" element={<NotFound />} />
+    </ReactRouterRoutes>
+  )
 }
 
 function useRoutes(pages) {

--- a/assets/empty-state.svg
+++ b/assets/empty-state.svg
@@ -1,0 +1,1 @@
+<svg width="140" height="140" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M70 40a30 30 0 100 60 30 30 0 000-60zm-3 15a3 3 0 116 0v15a3 3 0 11-6 0V55zm3 32a4 4 0 110-8 4 4 0 010 8z" fill="#8C9196"/></svg>

--- a/assets/index.js
+++ b/assets/index.js
@@ -1,0 +1,2 @@
+export { default as notFoundImage } from './empty-state.svg'
+export { default as trophyImage } from './home-trophy.png'

--- a/pages/NotFound.jsx
+++ b/pages/NotFound.jsx
@@ -1,0 +1,23 @@
+import { Card, EmptyState, Page } from '@shopify/polaris'
+import { notFoundImage } from 'assets'
+
+export default function NotFound() {
+  return (
+    <Page fullWidth>
+      <Card>
+        <Card.Section>
+          <EmptyState
+            heading="There is no page at this address"
+            image={notFoundImage}
+            fullWidth
+          >
+            <p>
+              Check the URL and try again, or use the search bar to find what
+              you need.
+            </p>
+          </EmptyState>
+        </Card.Section>
+      </Card>
+    </Page>
+  )
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -9,7 +9,7 @@ import {
   Heading,
 } from "@shopify/polaris";
 
-import trophyImgUrl from "assets/home-trophy.png";
+import { trophyImage } from 'assets'
 
 import { ProductsCard } from "components/ProductsCard";
 
@@ -66,7 +66,7 @@ export default function HomePage() {
               <Stack.Item>
                 <div style={{ padding: "0 20px" }}>
                   <Image
-                    source={trophyImgUrl}
+                    source={trophyImage}
                     alt="Nice work on building a Shopify app"
                     width={120}
                   />


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/first-party-library-planning/issues/242

Supporting improved developer experience and general app best practices, this app should provide a fallback "not found" page.

### WHAT is this pull request doing?

This PR provides a fallback "not found" page.

![NotFound](https://user-images.githubusercontent.com/7654369/169915033-74fb988f-eaba-4c84-a56b-faa216455e7f.png)

Small cleanup:

- Add index to assets directory
- Export assets with matching naming conventions

## Testing this PR

- Clone and cd into `shopify-cli-next`
- Run the following command to generate an app using this template
```
yarn build:affected && yarn create-app --template=https://github.com/Shopify/starter-node-app#elana-test-branch --local --name=test_app
```

- Run `cd test-app`
- Run `yarn dev --tunnel`
- Navigate to a non-existent path

The `NotFound` page should appear and match the [Figma design](https://www.figma.com/file/13VXYtW2vOltT8mD35K7uF/App-Template-and-Sample-App?node-id=419%3A23034).