### PR TITLE
Remove fullWidth so pages and cards

### DIFF
--- a/pages/NotFound.jsx
+++ b/pages/NotFound.jsx
@@ -3,13 +3,12 @@ import { notFoundImage } from 'assets'
 
 export default function NotFound() {
   return (
-    <Page fullWidth>
+    <Page>
       <Card>
         <Card.Section>
           <EmptyState
             heading="There is no page at this address"
             image={notFoundImage}
-            fullWidth
           >
             <p>
               Check the URL and try again, or use the search bar to find what

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -15,7 +15,7 @@ import { ProductsCard } from "components/ProductsCard";
 
 export default function HomePage() {
   return (
-    <Page fullWidth>
+    <Page>
       <Layout>
         <Layout.Section>
           <Card sectioned>

--- a/pages/tab2.jsx
+++ b/pages/tab2.jsx
@@ -2,7 +2,7 @@ import { Card, Page, Layout, TextContainer, Heading } from '@shopify/polaris'
 
 export default function Tab2() {
   return (
-    <Page fullWidth>
+    <Page>
       <Layout>
         <Layout.Section>
           <Card sectioned>


### PR DESCRIPTION

### WHY are these changes introduced?

We shouldn't be rendering the page at full width, but should instead be relying on Polaris' standard layout width.


### WHAT is this pull request doing?

This change removes the `fullWidth` prop from the Page components in the app template, as well as the Card for the 404 page.
