### PR TITLE
Renaming tabs to pages

### DIFF
--- a/components/TitleBarSection.jsx
+++ b/components/TitleBarSection.jsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom'
 
 export function TitleBarSection() {
   const { pathname } = useLocation()
-  const showButtons = pathname === '/tab2'
+  const showButtons = pathname === '/page2'
 
   return (
     <>
@@ -31,12 +31,12 @@ export function TitleBarSection() {
       <NavigationMenu
         navigationLinks={[
           {
-            label: 'Tab 1',
+            label: 'Page 1',
             destination: '/',
           },
           {
-            label: 'Tab 2',
-            destination: '/tab2',
+            label: 'Page 2',
+            destination: '/page2',
           },
         ]}
       />

--- a/pages/page2.jsx
+++ b/pages/page2.jsx
@@ -1,6 +1,6 @@
 import { Card, Page, Layout, TextContainer, Heading } from '@shopify/polaris'
 
-export default function Tab2() {
+export default function Page2() {
   return (
     <Page>
       <Layout>


### PR DESCRIPTION
### WHY are these changes introduced?

The Navigation menu and routes should be called 'Pages' rather than 'Tabs', since they will soon appear in the left nav.


### WHAT is this pull request doing?

- Renames the `tab2` route to `page2`
- Renames the labels in the navigation menu from Tab 1 and Tab 2 to Page 1 and Page 2.

After view:
<img width="1572" alt="Screen Shot 2022-05-27 at 11 00 37 AM" src="https://user-images.githubusercontent.com/421723/170725868-5e5b9d89-9c88-45e4-9612-1ef62d820c2b.png">
<img width="1662" alt="Screen Shot 2022-05-27 at 11 00 42 AM" src="https://user-images.githubusercontent.com/421723/170725877-b0b0df28-afca-4159-a33d-4d5d3183712c.png">

