### PR TITLE
Show - instead of 0 while product count loads

### DIFF
--- a/components/ProductsCard.jsx
+++ b/components/ProductsCard.jsx
@@ -29,7 +29,7 @@ export function ProductsCard() {
   const [populateProduct, { isLoading }] = useShopifyMutation({
     query: PRODUCTS_QUERY,
   })
-  const [productCount, setProductCount] = useState(0)
+  const [productCount, setProductCount] = useState('-')
   const [hasResults, setHasResults] = useState(false)
 
   async function updateProductCount() {


### PR DESCRIPTION
This is quite a simple update, just to change the initial value of the product count while the actual number loads.