### PR TITLE
Add documentation to the Polaris provider

### DIFF
--- a/components/providers/PolarisProvider.jsx
+++ b/components/providers/PolarisProvider.jsx
@@ -27,6 +27,26 @@ function AppBridgeLink({ url, children, className, external, ...rest }) {
   )
 }
 
+/**
+ * Sets up the AppProvider from Polaris.
+ * @desc PolarisProvider passes a custom link component to Polaris.
+ * The Link component handles navigation within an embedded app.
+ * Prefer using this vs any other method such as an anchor.
+ * Use it by importing Link from Polaris, e.g:
+ *
+ * ```
+ * import {Link} from '@shopify/polaris'
+ *
+ * function MyComponent() {
+ *  return (
+ *    <div><Link url="/tab2">Tab 2</Link></div>
+ *  )
+ * }
+ * ```
+ *
+ * PolarisProvider also passes translations to Polaris.
+ *
+ */
 export function PolarisProvider({ children }) {
   return (
     <AppProvider i18n={translations} linkComponent={AppBridgeLink}>


### PR DESCRIPTION
### WHY are these changes introduced?

We document all the providers except for this one. I think documenting this provider is an opportunity to:

1. Steer developers towards using the correct Link component
2. Providing context on how embedded apps are different.

### WHAT is this pull request doing?

Adding doc block comment.s