### PR TITLE
Fix Vite reloads crashing AppBridge

### DIFF
--- a/components/providers/AppBridgeProvider.jsx
+++ b/components/providers/AppBridgeProvider.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Provider } from '@shopify/app-bridge-react'
 


### PR DESCRIPTION
Just upstreaming Shopify/shopify-app-examples#56.