### PR TITLE
Always use REMOTE redirect for re-auth

### DIFF
--- a/hooks/useAuthenticatedFetch.js
+++ b/hooks/useAuthenticatedFetch.js
@@ -32,9 +32,11 @@ function checkHeadersForReauthorization(headers, app) {
       `/api/auth`
 
     const redirect = Redirect.create(app)
-    const redirectType = authUrlHeader.startsWith('/')
-      ? Redirect.Action.APP
-      : Redirect.Action.REMOTE
-    redirect.dispatch(redirectType, authUrlHeader)
+    redirect.dispatch(
+      Redirect.Action.REMOTE,
+      authUrlHeader.startsWith('/')
+        ? `https://${window.location.host}${authUrlHeader}`
+        : authUrlHeader
+    )
   }
 }


### PR DESCRIPTION
Fixes https://github.com/Shopify/first-party-library-planning/issues/297

As per https://github.com/Shopify/first-party-library-planning/issues/297#issuecomment-1141448013, this was not a bug, but us using `APP` redirects when we didn't want them. When re-authenticating, we always want to start from a top-level request to minimize the number of redirects, so we should always be doing `REMOTE` redirects.