### PR TITLE
Add warnings about missing API key env var

### DIFF
--- a/components/providers/AppBridgeProvider.jsx
+++ b/components/providers/AppBridgeProvider.jsx
@@ -37,7 +37,7 @@ export function AppBridgeProvider({ children }) {
         <Layout>
           <Layout.Section>
             <div style={{ marginTop: '100px' }}>
-              <Banner title="Missing Shopify App key" status="critical">
+              <Banner title="Missing Shopify API key" status="critical">
                 Your app is running without the SHOPIFY_API_KEY environment
                 variable. Please ensure that it is set when running or building
                 your React app.

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,7 @@ if (
   !process.env.SHOPIFY_API_KEY
 ) {
   console.warn(
-    '\nBuilding frontend app without an API key, this will produce a non-runnable frontend. Please set the SHOPIFY_API_KEY environment variable\n'
+    '\nBuilding the frontend app without an API key. The frontend build will not run without an API key. Set the SHOPIFY_API_KEY environment variable when running the build command.\n'
   )
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

When building the App Bridge client in the FE app, it needs to receive the App key to build with via the `SHOPIFY_API_KEY` env var. If that var is missing, we'll currently silently ignore it when running the app or building it for production.

That leads to a blank screen and a console error, which while helpful doesn't really tell the developer how to fix it.

### WHAT is this pull request doing?

This PR covers two instances to help guide developers:
1. When building the app, it shows a console warning to let the developer know they're building a non-runnable app
    ![image](https://user-images.githubusercontent.com/64600052/171277141-e7195498-eb41-4705-bf44-24535a9d5d9d.png)
1. When running the app, it renders a helpful error message telling the developer why the app refused to run
    <img width="812" alt="Screen Shot 2022-05-31 at 4 07 09 PM" src="https://user-images.githubusercontent.com/64600052/171275827-81d97b38-c8f7-452b-be28-8c12f6a005fa.png">