### PR TITLE
Ensure that all props are passed to the anchor

### DIFF
--- a/components/providers/PolarisProvider.jsx
+++ b/components/providers/PolarisProvider.jsx
@@ -4,13 +4,13 @@ import { useNavigate } from '@shopify/app-bridge-react'
 import translations from '@shopify/polaris/locales/en.json'
 import '@shopify/polaris/build/esm/styles.css'
 
-function AppBridgeLink({ url, children, className, external, ...rest }) {
+function AppBridgeLink({ url, children, external, ...rest }) {
   const navigate = useNavigate()
   const handleClick = useCallback(() => {
     navigate(url)
   }, [url])
 
-  const IS_EXTERNAL_LINK_REGEX = /^(?:[a-z][a-z\d+.-]*:|\/\/)/;
+  const IS_EXTERNAL_LINK_REGEX = /^(?:[a-z][a-z\d+.-]*:|\/\/)/
 
   if (external || IS_EXTERNAL_LINK_REGEX.test(url)) {
     return (
@@ -21,7 +21,7 @@ function AppBridgeLink({ url, children, className, external, ...rest }) {
   }
 
   return (
-    <a onClick={handleClick} {...{ className }}>
+    <a onClick={handleClick} {...rest}>
       {children}
     </a>
   )


### PR DESCRIPTION
This is important, because the user may add a data attribute to the Link component. Without these changes, that attribute would not be rendered on the actual anchor element

### WHY are these changes introduced?
More detail here: https://github.com/Shopify/shopify-app-examples/pull/68

