### PR TITLE
Fix: Add config for pnpm dev to work

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,9 @@ export default defineConfig({
   esbuild: {
     jsxInject: `import React from 'react'`,
   },
+  resolve: {
+    preserveSymlinks: true,
+  },
   server: {
     port: process.env.FRONTEND_PORT,
     middlewareMode: 'html',


### PR DESCRIPTION
### WHY are these changes introduced?

Using `pnpm dev` to do a local deployment resulted in some files (within `node_modules/.pnpm`) not being found (returning `404` to FE).

### WHAT is this pull request doing?

Adds `resolve.preserveSymlinks` to `vite.config.js` to resolve issue, also requires https://github.com/Shopify/shopify-app-template-node/pull/850