### PR TITLE
Change license field to UNLICENSED

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shopify-frontend-template-react",
   "private": true,
-  "license": "MIT",
+  "license": "UNLICENSED",
   "scripts": {
     "build": "vite build",
     "dev": "cross-env NODE_ENV=development node vite-server.js",
@@ -41,5 +41,5 @@
     "tabWidth": 2,
     "semi": false,
     "singleQuote": true
-  } 
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To make the `"license"` field in the `package.json` file consistent with those in `shopify-app-template-*`

### WHAT is this pull request doing?

Change the `"license"`from `"MIT"` to `"UNLICENSED"` in `package.json`