### PR TITLE
fix: change page titles to match pathname

### DIFF
--- a/components/TitleBarSection.jsx
+++ b/components/TitleBarSection.jsx
@@ -4,11 +4,12 @@ import { useLocation } from 'react-router-dom'
 export function TitleBarSection() {
   const { pathname } = useLocation()
   const showButtons = pathname === '/page2'
-
+  const pageTitle = pathname === '/' ? 'Page 1' : 'Page 2'
+  
   return (
     <>
       <TitleBar
-        title="App Name"
+        title={pageTitle}
         primaryAction={
           showButtons
             ? {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

Replaces the `App Name` on the title bar to the page it is one. 

### WHY are these changes introduced?

Fixes  [#333](https://github.com/Shopify/first-party-library-planning/issues/333)

To have the Titlebar naming be consistent with the side navigation bar. 

### WHAT is this pull request doing?
Previously the app template was showing `App Name` instead of the page it is on the Titlebar. With this PR change it is changing the title bar conditionally if it is Page 1 or Page 2. 

You need to enable the new sub-nav UX in our stores and in our local app builds. Here are the steps to set that up for a local build:

Enable the admin_app_pinning beta flag on the dev store. [Services Internal](https://www.google.com/url?q=https://app.shopify.com/services/internal/shops/&sa=D&source=calendar&ust=1655066664714319&usg=AOvVaw3ljAADUZaanyZ4U73sma76) -> find dev store -> Scroll to Beta features -> Click Show -> Click Add more -> enable flag

Enable the app_bridge_sidebar_app_navigation beta flag on your partner organization. [Partners Internal](https://www.google.com/url?q=https://partners.shopify.com/internal&sa=D&source=calendar&ust=1655066664714319&usg=AOvVaw0iDZMxtRHmIDDzxF6STzuF) -> Apps -> search for your app -> click Edit on app page -> select Beta flags tab -> enable app_bridge_sidebar_app_navigation and click Save.

BEFORE: 

![image](https://user-images.githubusercontent.com/78764587/172728905-ea01aaa6-92aa-41dc-9e10-84aac8cbb97c.png)

![image](https://user-images.githubusercontent.com/78764587/172728929-e1245421-6b48-4152-a710-76654b32939c.png)


AFTER: 
<img width="1209" alt="Screen Shot 2022-06-08 at 4 29 40 PM" src="https://user-images.githubusercontent.com/78764587/172728986-e2f96cbc-554f-4795-b098-3d6e3ba37e97.png">

<img width="1215" alt="Screen Shot 2022-06-08 at 4 29 53 PM" src="https://user-images.githubusercontent.com/78764587/172728988-ada6b629-7539-4b3d-8ccb-e615c38923f9.png">

Notes: 
Note 1:
@elanalynn  and I tried to double check our work by pointing the test app to the `fix/page-titles` branch, but we were not successful. So I don't have top hat instructions, but it worked locally.

Note 2: 
When `page 1` or `page 2` is clicked in the navigation menu it redirects to the myshopify store instead of directing to the `page 1` or `page 2` of the application. This is not related to this PR's changes, but a possible issue in the code. 

Here is a video of the issue: 

https://user-images.githubusercontent.com/78764587/172729538-d05ccfe2-9066-42b8-ba40-bafedd95e523.mov

