### PR TITLE
chore: add useAppQuery hook in ProductsCard

### DIFF
--- a/hooks/index.js
+++ b/hooks/index.js
@@ -1,3 +1,4 @@
+export { useAppQuery } from './useAppQuery'
 export { useAuthenticatedFetch } from './useAuthenticatedFetch'
 export { useShopifyMutation } from './useShopifyMutation'
 export { useShopifyQuery } from './useShopifyQuery'

--- a/hooks/useAppQuery.js
+++ b/hooks/useAppQuery.js
@@ -1,0 +1,30 @@
+import { useAuthenticatedFetch } from './useAuthenticatedFetch'
+import { useMemo } from 'react'
+import { useQuery } from 'react-query'
+
+/**
+ * A hook for querying your custom app data.
+ * @desc A thin wrapper around useAuthenticatedFetch and react-query's useQuery.
+ *
+ * @param {Object} options - The options for your query. Accepts 3 keys:
+ *
+ * 1. url: The URL to query. E.g: /api/widgets/1`
+ * 2. fetchInit: The init options for fetch.  See: https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters
+ * 3. reactQueryOptions: The options for `useQuery`. See: https://react-query.tanstack.com/reference/useQuery
+ *
+ * @returns Return value of useQuery.  See: https://react-query.tanstack.com/reference/useQuery.
+ */
+export const useAppQuery = ({ url, fetchInit = {}, reactQueryOptions }) => {
+  const authenticatedFetch = useAuthenticatedFetch()
+  const fetch = useMemo(() => {
+    return async () => {
+      const response = await authenticatedFetch(url, fetchInit)
+      return response.json()
+    }
+  }, [url, JSON.stringify(fetchInit)])
+
+  return useQuery(url, fetch, {
+    ...reactQueryOptions,
+    refetchOnWindowFocus: false,
+  })
+}


### PR DESCRIPTION
chore: add useAppQuery hook to ProductsCard


### WHY are these changes introduced?

Fixes [#323](https://github.com/Shopify/first-party-library-planning/issues/323)
Fixes [#322](https://github.com/Shopify/first-party-library-planning/issues/322)

Implements the useAppQuery hook created in the QR Example App into the template 

### WHAT is this pull request doing?

- Removes the useAuthentification hook from the ProductsCard component and uses useAppQuery to fetch and refetch product count. 
- Removes unnecessary imports, like `button`, `useAuthentification`, `useRef`
- Imports `useAppQuery` to index and component

To TopHat : 
- `dev clone shopify-frontend-template-react`
- `git checkout <chore/add-useAppQuery>`
- In some test folder elsewhere, scaffold an app - `yarn create @shopify/app`
- `cd my-app-folder`
- `mv web/frontend web/frontend_ignore`
- `ln -s $HOME/src/github.com/Shopify/shopify-frontend-template-react web/frontend`
- `yarn dev`