### PR TITLE
fix: change navigation link

### DIFF
--- a/components/TitleBarSection.jsx
+++ b/components/TitleBarSection.jsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom'
 
 export function TitleBarSection() {
   const { pathname } = useLocation()
-  const showButtons = pathname === '/page2'
+  const showButtons = pathname === '/page'
 
   return (
     <>
@@ -31,12 +31,8 @@ export function TitleBarSection() {
       <NavigationMenu
         navigationLinks={[
           {
-            label: 'Page 1',
-            destination: '/',
-          },
-          {
-            label: 'Page 2',
-            destination: '/page2',
+            label: 'Page',
+            destination: '/page',
           },
         ]}
       />

--- a/pages/page.jsx
+++ b/pages/page.jsx
@@ -1,8 +1,8 @@
-import { Card, Page, Layout, TextContainer, Heading } from '@shopify/polaris'
+import { Card, Page as PolarisPage, Layout, TextContainer, Heading } from '@shopify/polaris'
 
-export default function Page2() {
+export default function Page() {
   return (
-    <Page>
+    <PolarisPage>
       <Layout>
         <Layout.Section>
           <Card sectioned>
@@ -27,6 +27,6 @@ export default function Page2() {
           </Card>
         </Layout.Section>
       </Layout>
-    </Page>
+    </PolarisPage>
   )
 }


### PR DESCRIPTION

### WHY are these changes introduced?
The index page and page 1 were both directing to `'/'`, and the nav links were automatically highlighting `page1` instead of the app name. 

Fixes [#338](https://github.com/Shopify/first-party-library-planning/issues/338)


### WHAT is this pull request doing?
Updates the index page to be at the side-nav root, rather than as a subpage 
- instead of having a app name, with two sub directories `page 1` and `page 2` the app now has the index page at the root / top level nav and a singular `page` as its subpage 

prev: 
Updates the index page to be at the side-nav root, rather than as a subpage 



https://user-images.githubusercontent.com/78764587/173159955-1667a2cc-5008-49d6-b026-07960b127c99.mov


https://user-images.githubusercontent.com/78764587/173159559-72581f14-db3a-4103-9df4-c082c512b0a2.mov

ISSUES: 
- when clicking on `Page` on the side nav bar, it takes you to the shopify store. However, if you append `/page` to the end of the url it will take you to the `page`. When the user is on the `page` the `Page` link on the sidebar is not highlighted. I am not sure if this is an issue with the redirect going to the Shopify store or something with needing to set this in this code. 

NOTE: 
- still need at add bread crumbs after this PR has been merged