### PR TITLE
Obtain the root directory using fileURLToPath and dirname

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,6 @@
 import { defineConfig } from 'vite'
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 // prettier-ignore
 const INDEX_ROUTE = "^/(\\?.*)?$";
@@ -14,7 +16,7 @@ if (
   )
 }
 
-const root = new URL('.', import.meta.url).pathname
+const root = dirname(fileURLToPath(import.meta.url))
 export default defineConfig({
   root,
   define: {


### PR DESCRIPTION
### WHY are these changes introduced?
While testing the CLI on Windows we found out that the `frontend` the Vite configuration file doesn't yield the expected results.

### WHAT is this pull request doing?
It fixes the issue by using `dirname(fileURLToPath(import.meta.url))` for obtaining the directory containing the file. This is the suggested method in ESM to construct the `__dirname` variable that's available in CJS.