### PR TITLE
Update AppBridge to latest version

### DIFF
--- a/components/providers/AppBridgeProvider.jsx
+++ b/components/providers/AppBridgeProvider.jsx
@@ -3,8 +3,6 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { Provider } from '@shopify/app-bridge-react'
 import { Banner, Layout, Page } from '@shopify/polaris'
 
-const APPBRIDGE_HOST = new URLSearchParams(location.search).get('host')
-
 /**
  * A component to configure App Bridge.
  * @desc A thin wrapper around AppBridgeProvider that provides the following capabilities:
@@ -31,6 +29,15 @@ export function AppBridgeProvider({ children }) {
     [history, location]
   )
 
+  const appBridgeConfig = useMemo(
+    () => ({
+      apiKey: process.env.SHOPIFY_API_KEY,
+      host: new URLSearchParams(location.search).get('host'),
+      forceRedirect: true,
+    }),
+    [process.env.SHOPIFY_API_KEY, location.search]
+  )
+
   if (!process.env.SHOPIFY_API_KEY) {
     return (
       <Page narrowWidth>
@@ -50,14 +57,7 @@ export function AppBridgeProvider({ children }) {
   }
 
   return (
-    <Provider
-      config={{
-        apiKey: process.env.SHOPIFY_API_KEY,
-        host: APPBRIDGE_HOST,
-        forceRedirect: true,
-      }}
-      router={routerConfig}
-    >
+    <Provider config={appBridgeConfig} router={routerConfig}>
       {children}
     </Provider>
   )

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "node": ">= 12.16"
   },
   "dependencies": {
-    "@shopify/app-bridge": "^2.0.25",
-    "@shopify/app-bridge-react": "^2.0.25",
-    "@shopify/app-bridge-utils": "^2.0.25",
+    "@shopify/app-bridge": "^3.1.0",
+    "@shopify/app-bridge-react": "^3.1.0",
+    "@shopify/app-bridge-utils": "^3.1.0",
     "@shopify/polaris": "^9.11.0",
     "@vitejs/plugin-react": "1.2.0",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
### WHY are these changes introduced?
The latest version of AppBridge reverts a change to how props are considered by the AppBridge Provider.  Historically changes to these props were ignored.  Then we released a version where changes to the props were considered.  This broke some 3P apps, so in this version we revert the changes.

The changes to how we memoize the AppBridge provider props are not strictly needed (because of the above described behaviour).  But it makes sense to make this change anyway, just as an idiomatic best practice.

### WHAT is this pull request doing?

1. Update AppBridge to the latest version
2. Change how we memoize the props we pass to the Appbridge provider.
