### PR TITLE
Fix an error where Appbridge would be initialized without a host

### DIFF
--- a/components/providers/AppBridgeProvider.jsx
+++ b/components/providers/AppBridgeProvider.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Provider } from '@shopify/app-bridge-react'
 import { Banner, Layout, Page } from '@shopify/polaris'
@@ -29,14 +29,24 @@ export function AppBridgeProvider({ children }) {
     [history, location]
   )
 
-  const appBridgeConfig = useMemo(
-    () => ({
+  // The host may be present initially, but later removed by navigation.
+  // By caching this in state, we ensure that the host is never lost.
+  // During the lifecycle of an app, these values should never be updated anyway.
+  // Using state in this way is preferable to useMemo.
+  // See: https://stackoverflow.com/questions/60482318/version-of-usememo-for-caching-a-value-that-will-never-change
+  const [appBridgeConfig] = useState(() => {
+    const host =
+      new URLSearchParams(location.search).get('host') ||
+      sessionStorage.getItem('host')
+
+    sessionStorage.setItem('host', host)
+
+    return {
+      host,
       apiKey: process.env.SHOPIFY_API_KEY,
-      host: new URLSearchParams(location.search).get('host'),
       forceRedirect: true,
-    }),
-    [process.env.SHOPIFY_API_KEY, location.search]
-  )
+    }
+  })
 
   if (!process.env.SHOPIFY_API_KEY) {
     return (


### PR DESCRIPTION
### WHY are these changes introduced?
Previously when you made some changes to the apps codebase AppBridge could reinitialize without the host being preset in the URL.  This meant that AppBridge was reinitialized with undefined as a host.  AppBridge would throw an error, and the app would fail to render.

The solution here is to cache the host in session storage.  This way, even if the host is removed from the URL, the app can still access it from session storage.

To be clear, this should only ever be an issue in development mode.  In development mode individual modules can be swapped out at run time.  This can lead to AppBridge be reinitialized, after the host has been removed from the URL.  This should not be possible in production, because the code is static and should never change.  As such, in production, this is overkill.  But it has very little cost, and improves Dev X, so seems a worthy tradeoff.

### WHAT is this pull request doing?
1. Store the host in session storage.  That way if the HMR reloads the AppBridgeProvider, 
2. use useState, rather than useMemo to cache the provide value.  The comment explains why.

### Testing this PR

First, let's confirm the issue without these changes.

1. Use the CLI to create a new app.
2. run `yarn dev` to preview the app.
3. Now make a change to `title` prop of the `<TitleBar/>` component.
4. You should see this error:

<img width="959" alt="Screen Shot 2022-06-15 at 2 43 49 PM" src="https://user-images.githubusercontent.com/690791/173903366-d9e4a1b2-8d26-433d-9ad2-9df977560a79.png">

Now let's try to reproduce the issue with these changes.

1. Copy the changes from this PR into your App.
2. Run `yarn dev` to preview the app.
3. Now make a change to `title` prop of the `<TitleBar/>` component.
4. There should be no error.


