### PR TITLE
Fix /api route for proxying

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,10 @@
 import { defineConfig } from 'vite'
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname } from 'path'
+import { fileURLToPath } from 'url'
 
 // prettier-ignore
 const INDEX_ROUTE = "^/(\\?.*)?$";
-const API_ROUTE = '^/api/'
+const API_ROUTE = '^/api(/|(\\?.*)?$)'
 
 if (
   process.env.npm_lifecycle_event === 'build' &&


### PR DESCRIPTION
### WHY are these changes introduced?

There are cases where we might end up at `/api` - and the FE proxying fails in that case because it expects it to be `/api/`.

### WHAT is this pull request doing?

Fixing that to handle the `/api$` case.