### PR TITLE
Stop using sessionStorage

### DIFF
--- a/components/providers/AppBridgeProvider.jsx
+++ b/components/providers/AppBridgeProvider.jsx
@@ -37,9 +37,9 @@ export function AppBridgeProvider({ children }) {
   const [appBridgeConfig] = useState(() => {
     const host =
       new URLSearchParams(location.search).get('host') ||
-      sessionStorage.getItem('host')
+      window.__SHOPIFY_DEV_HOST
 
-    sessionStorage.setItem('host', host)
+    window.__SHOPIFY_DEV_HOST = host
 
     return {
       host,


### PR DESCRIPTION
When in an iframe on a browser that's blocking 3rd party cookies, `sessionStorage` isn't accessible. Since we don't want to rely on any form of 3rd party cookies, we should just not do it.

I'm replacing the `sessionStorage` with a `window` variable so that we don't lose the host when HMR triggers.