### PR TITLE
Show error page for missing URL host

### DIFF
--- a/components/providers/AppBridgeProvider.jsx
+++ b/components/providers/AppBridgeProvider.jsx
@@ -48,17 +48,35 @@ export function AppBridgeProvider({ children }) {
     };
   });
 
-  if (!process.env.SHOPIFY_API_KEY) {
+  if (!process.env.SHOPIFY_API_KEY || !appBridgeConfig.host) {
+    const bannerProps = !process.env.SHOPIFY_API_KEY
+      ? {
+          title: "Missing Shopify API Key",
+          children: (
+            <>
+              Your app is running without the SHOPIFY_API_KEY environment
+              variable. Please ensure that it is set when running or building
+              your React app.
+            </>
+          ),
+        }
+      : {
+          title: "Missing host query argument",
+          children: (
+            <>
+              Your app can only load if the URL has a <b>host</b> argument.
+              Please ensure that it is set, or access your app using the
+              Partners Dashboard <b>Test your app</b> feature
+            </>
+          ),
+        };
+
     return (
       <Page narrowWidth>
         <Layout>
           <Layout.Section>
             <div style={{ marginTop: "100px" }}>
-              <Banner title="Missing Shopify API key" status="critical">
-                Your app is running without the SHOPIFY_API_KEY environment
-                variable. Please ensure that it is set when running or building
-                your React app.
-              </Banner>
+              <Banner {...bannerProps} status="critical" />
             </div>
           </Layout.Section>
         </Layout>


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, if the app is loaded by visiting the ngrok address without any query args, we just fail with a blank screen, which isn't very informative.

### WHAT is this pull request doing?

Adding this message if we fail to find a host in the URL

![image](https://user-images.githubusercontent.com/64600052/174904778-592dbd4f-10b7-4073-8766-cc71220a16b3.png)
