### PR TITLE
Remove GraphQL dependency and rename provider

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -4,7 +4,7 @@ import Routes from "./Routes";
 
 import {
   AppBridgeProvider,
-  GraphQLProvider,
+  QueryProvider,
   PolarisProvider,
 } from "./components";
 
@@ -17,7 +17,7 @@ export default function App() {
     <PolarisProvider>
       <BrowserRouter>
         <AppBridgeProvider>
-          <GraphQLProvider>
+          <QueryProvider>
             <NavigationMenu
               navigationLinks={[
                 {
@@ -27,7 +27,7 @@ export default function App() {
               ]}
             />
             <Routes pages={pages} />
-          </GraphQLProvider>
+          </QueryProvider>
         </AppBridgeProvider>
       </BrowserRouter>
     </PolarisProvider>

--- a/components/ProductsCard.jsx
+++ b/components/ProductsCard.jsx
@@ -7,7 +7,6 @@ import {
   TextStyle,
 } from "@shopify/polaris";
 import { Toast } from "@shopify/app-bridge-react";
-import { gql } from "graphql-request";
 import { useAppQuery, useAuthenticatedFetch } from "../hooks";
 
 export function ProductsCard() {

--- a/components/providers/QueryProvider.jsx
+++ b/components/providers/QueryProvider.jsx
@@ -9,7 +9,7 @@ import {
  * Sets up the QueryClientProvider from react-query.
  * @desc See: https://react-query.tanstack.com/reference/QueryClientProvider#_top
  */
-export function GraphQLProvider({ children }) {
+export function QueryProvider({ children }) {
   const client = new QueryClient({
     queryCache: new QueryCache(),
     mutationCache: new MutationCache(),

--- a/components/providers/index.js
+++ b/components/providers/index.js
@@ -1,3 +1,3 @@
 export { AppBridgeProvider } from "./AppBridgeProvider";
-export { GraphQLProvider } from "./GraphQLProvider";
+export { QueryProvider } from "./QueryProvider";
 export { PolarisProvider } from "./PolarisProvider";

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "@shopify/app-bridge-utils": "^3.1.0",
     "@shopify/polaris": "^9.11.0",
     "@vitejs/plugin-react": "1.2.0",
-    "graphql": "^16.3.0",
-    "graphql-request": "^4.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-query": "^3.34.19",

--- a/test/mount.jsx
+++ b/test/mount.jsx
@@ -4,7 +4,7 @@ import { PolarisTestProvider } from "@shopify/polaris";
 import { AppBridgeContext } from "@shopify/app-bridge-react/context";
 import { BrowserRouter } from "react-router-dom";
 import { createBrowserHistory } from "history";
-import { GraphQLProvider } from "../components";
+import { QueryProvider } from "../components";
 
 function createMockApp() {
   const localOrigin = "https://example.com";
@@ -37,7 +37,7 @@ export const mount = createMount({
       <PolarisTestProvider>
         <BrowserRouter>
           <AppBridgeContext.Provider value={createMockApp()}>
-            <GraphQLProvider>{element}</GraphQLProvider>
+            <QueryProvider>{element}</QueryProvider>
           </AppBridgeContext.Provider>
         </BrowserRouter>
       </PolarisTestProvider>


### PR DESCRIPTION
### WHY are these changes introduced?

Since we're no longer writing GraphQL queries straight in the FE code, we don't need to import any GraphQL dependencies by default.

### WHAT is this pull request doing?

Removing some unnecessary imports.

Also, the `GraphQLProvider` component was actually providing `react-query` as a whole (which also works for REST queries), I renamed it to something more generic, since it'll help with any app queries, not just GQL ones.