### PR TITLE
Add page to break out of the iframe

### DIFF
--- a/pages/ExitIframe.jsx
+++ b/pages/ExitIframe.jsx
@@ -1,0 +1,27 @@
+import { Redirect } from "@shopify/app-bridge/actions";
+import { useAppBridge, Loading } from "@shopify/app-bridge-react";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ExitIframe() {
+  const app = useAppBridge();
+  const { search } = useLocation();
+
+  useEffect(() => {
+    if (!!app && !!search) {
+      const params = new URLSearchParams(search);
+      const redirectUri = params.get("redirectUri");
+      const url = new URL(redirectUri);
+
+      if (url.hostname === location.hostname) {
+        const redirect = Redirect.create(app);
+        redirect.dispatch(
+          Redirect.Action.REMOTE,
+          decodeURIComponent(redirectUri)
+        );
+      }
+    }
+  }, [app, search]);
+
+  return <Loading />;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Sometimes apps might need to break out of the iframe when not using the `useAuthenticatedFetch` hook, like on a full page reload that requires an OAuth loop.

### WHAT is this pull request doing?

Adding a new page that apps can redirect to with a `redirectUri` query arg that will break out of the admin iframe and redirect at the top level.