### PR TITLE
Decode URI component in ExitIframe page

### DIFF
--- a/pages/ExitIframe.jsx
+++ b/pages/ExitIframe.jsx
@@ -11,7 +11,7 @@ export default function ExitIframe() {
     if (!!app && !!search) {
       const params = new URLSearchParams(search);
       const redirectUri = params.get("redirectUri");
-      const url = new URL(redirectUri);
+      const url = new URL(decodeURIComponent(redirectUri));
 
       if (url.hostname === location.hostname) {
         const redirect = Redirect.create(app);


### PR DESCRIPTION
This PR is just fixing an issue with the `/ExitIframe` page - it wasn't decoding the URI component, so we might end up with a faulty URL.