### PR TITLE
Add a viewport meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+
+    <!-- Ensures that the UI is properly scaled in the Shopify Mobile app -->
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <script type="module">
       if (!import.meta.env || !import.meta.env.PROD) {
         // Because the base HTML is rendered in the server side, we need to manually embed the code to enable HMR in our


### PR DESCRIPTION
### WHY are these changes introduced?

Adding this viewport meta tag ensures that the app renders at the right scale in the Shopify mobile app.  Without this the app renders twice:

1. The initial render which is zoomed out
2. A second render which is at the correct zoom level.  This happens when the Shopify mobile app injects the meta tag.

By adding the meta tag here we make sue it renders at the correct zoom level right away.

### WHAT is this pull request doing?

Adding a new meta tag