### PR TITLE
Fix Polaris Links

### DIFF
--- a/components/providers/PolarisProvider.jsx
+++ b/components/providers/PolarisProvider.jsx
@@ -14,14 +14,14 @@ function AppBridgeLink({ url, children, external, ...rest }) {
 
   if (external || IS_EXTERNAL_LINK_REGEX.test(url)) {
     return (
-      <a target="_blank" rel="noopener noreferrer" href={url} {...rest}>
+      <a {...rest} href={url} target="_blank" rel="noopener noreferrer">
         {children}
       </a>
     );
   }
 
   return (
-    <a onClick={handleClick} {...rest}>
+    <a {...rest} onClick={handleClick}>
       {children}
     </a>
   );


### PR DESCRIPTION
### WHY are these changes introduced?
In embedded apps we need to navigate using AppBridge.  That means converting an anchor with a href to an embedded app URL to an anchor with an onClick.  When onClick is called we ask AppBridge to navigate to that URL.  That way the URL in the Host updates (The Embedded app is rendered by an iFrame).

Currently this behaviour is broken because `props.onClick === undefined`.  That means when the anchor is rendered instead of onClick being `handleClick` it becomes undefined.

### WHAT is this pull request doing?
Reverse the order of spread props vs explicit props.  previously we would spread props after setting explicit props.  This would overwrite the explicit props, e.g:

```
anchorProps = {
   onClick={handleClick}
   ...rest
}
```

Now we overwrite the spread props with the props we want to explicitly control, e.g:

```
anchorProps = {
   ...rest
   onClick={handleClick}
}
```

### Testing this PR
1. Run `yarn create @shopify/app`
2. Add `<Link url="/pagename">pagename</Link>` to `/web/frontend/pages/index.jsx`
3. Click the link.  See that nothing happens.
4. Now apply the changes in this PR
5. Click the link.  The URL updates, and the page changes.


