### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+## 2022-06-21: Run prettier
+fa34bd26183ddc22701e2982288b33e6c8020f9e


### PR DESCRIPTION
### WHY are these changes introduced?

`git blame` in this repo is messy since there is a [Prettier commit](https://github.com/Shopify/shopify-frontend-template-react/commit/fa34bd26183ddc22701e2982288b33e6c8020f9e) that touches most lines.

### WHAT is this pull request doing?

Adds the commit to `.git-blame-ignore-revs` so it is ignored by GitHub's blame view.

**Before:**

<img width="364" alt="image" src="https://user-images.githubusercontent.com/1459385/199322110-9a73231f-21c9-4cf9-8c8e-f652c0117aa2.png">

**After:** 

<img width="389" alt="image" src="https://user-images.githubusercontent.com/1459385/199322236-85fb996e-97b4-4fa3-a558-be58a0283e7a.png">
