### PR TITLE
[Feature] Add Loading component when react query is fetching

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -6,8 +6,8 @@ import {
   AppBridgeProvider,
   QueryProvider,
   PolarisProvider,
-  LoadingProvider,
 } from "./components";
+import { ReactQueryLoading } from "./components/ReactQueryLoading";
 
 export default function App() {
   // Any .tsx or .jsx files in /pages will become a route
@@ -19,17 +19,16 @@ export default function App() {
       <BrowserRouter>
         <AppBridgeProvider>
           <QueryProvider>
-            <LoadingProvider>
-              <NavigationMenu
-                navigationLinks={[
-                  {
-                    label: "Page name",
-                    destination: "/pagename",
-                  },
-                ]}
-              />
-              <Routes pages={pages} />
-            </LoadingProvider>
+            <ReactQueryLoading />
+            <NavigationMenu
+              navigationLinks={[
+                {
+                  label: "Page name",
+                  destination: "/pagename",
+                },
+              ]}
+            />
+            <Routes pages={pages} />
           </QueryProvider>
         </AppBridgeProvider>
       </BrowserRouter>

--- a/components/ReactQueryLoading.jsx
+++ b/components/ReactQueryLoading.jsx
@@ -1,12 +1,7 @@
 import { useIsFetching } from "react-query";
 import { Loading } from "@shopify/app-bridge-react";
 
-export function LoadingProvider({ children }) {
+export function ReactQueryLoading() {
   const isFetching = useIsFetching();
-  return (
-    <>
-      {isFetching ? <Loading /> : null}
-      {children}
-    </>
-  );
+  return isFetching ? <Loading /> : null;
 }

--- a/components/providers/index.js
+++ b/components/providers/index.js
@@ -1,4 +1,3 @@
 export { AppBridgeProvider } from "./AppBridgeProvider";
 export { QueryProvider } from "./QueryProvider";
 export { PolarisProvider } from "./PolarisProvider";
-export { LoadingProvider } from "./LoadingProvider";


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHAT is this pull request doing?
It is using the React query [useIsFetching()](https://tanstack.com/query/v4/docs/reference/useIsFetching) hook to render an App Bridge [Loading](https://shopify.dev/apps/tools/app-bridge/actions/loading) component, whenever react query is fetching.

![image](https://user-images.githubusercontent.com/29695801/204864927-c0a86a60-b92a-4b51-b01d-f0920bb04d07.png)


<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->


### WHY are these changes introduced?
So that whenever react query is fetching data, the merchant can visually see that data is being fetched. This is especially useful when fetching in the background.
