### PR TITLE
Update react-router-dom v6.9.0, using createBrowserRouter and RouterProvider

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,35 +1,11 @@
-import { BrowserRouter } from "react-router-dom";
-import { NavigationMenu } from "@shopify/app-bridge-react";
-import Routes from "./Routes";
-
-import {
-  AppBridgeProvider,
-  QueryProvider,
-  PolarisProvider,
-} from "./components";
+import { AppRouterProvider, PolarisProvider, QueryProvider } from "./components";
 
 export default function App() {
-  // Any .tsx or .jsx files in /pages will become a route
-  // See documentation for <Routes /> for more info
-  const pages = import.meta.globEager("./pages/**/!(*.test.[jt]sx)*.([jt]sx)");
-
   return (
     <PolarisProvider>
-      <BrowserRouter>
-        <AppBridgeProvider>
-          <QueryProvider>
-            <NavigationMenu
-              navigationLinks={[
-                {
-                  label: "Page name",
-                  destination: "/pagename",
-                },
-              ]}
-            />
-            <Routes pages={pages} />
-          </QueryProvider>
-        </AppBridgeProvider>
-      </BrowserRouter>
+      <QueryProvider>
+        <AppRouterProvider />
+      </QueryProvider>
     </PolarisProvider>
   );
 }

--- a/components/ErrorBoundary.jsx
+++ b/components/ErrorBoundary.jsx
@@ -1,0 +1,26 @@
+import { Banner, Layout, Page } from "@shopify/polaris";
+import { useRouteError } from "react-router-dom";
+
+/**
+* ErrorBoundary
+* @desc General example error element
+* more details at https://reactrouter.com/en/main/route/error-element
+*/
+
+export default function ErrorBoundary() {
+  const error = useRouteError();
+
+  console.error(error);
+
+  return <Page narrowWidth>
+    <Layout>
+      <Layout.Section>
+        <div style={{ marginTop: "100px" }}>
+          <Banner title="Oh No!" status="critical">
+            <p>We encountered an error</p>
+          </Banner>
+        </div>
+      </Layout.Section>
+    </Layout>
+  </Page>
+}

--- a/components/ErrorBoundary.jsx
+++ b/components/ErrorBoundary.jsx
@@ -4,7 +4,8 @@ import { useRouteError } from "react-router-dom";
 /**
 * ErrorBoundary
 * @desc General example error element
-* more details at https://reactrouter.com/en/main/route/error-element
+*
+* See: https://reactrouter.com/en/main/route/error-element
 */
 
 export default function ErrorBoundary() {
@@ -17,7 +18,7 @@ export default function ErrorBoundary() {
       <Layout>
         <Layout.Section>
           <div style={{ marginTop: "100px" }}>
-            <Banner title="Oh No!" status="critical">
+            <Banner title="Something went wrong" status="critical">
               <p>We encountered an error</p>
             </Banner>
           </div>

--- a/components/ErrorBoundary.jsx
+++ b/components/ErrorBoundary.jsx
@@ -12,15 +12,17 @@ export default function ErrorBoundary() {
 
   console.error(error);
 
-  return <Page narrowWidth>
-    <Layout>
-      <Layout.Section>
-        <div style={{ marginTop: "100px" }}>
-          <Banner title="Oh No!" status="critical">
-            <p>We encountered an error</p>
-          </Banner>
-        </div>
-      </Layout.Section>
-    </Layout>
-  </Page>
+  return (
+    <Page narrowWidth>
+      <Layout>
+        <Layout.Section>
+          <div style={{ marginTop: "100px" }}>
+            <Banner title="Oh No!" status="critical">
+              <p>We encountered an error</p>
+            </Banner>
+          </div>
+        </Layout.Section>
+      </Layout>
+    </Page>
+  );
 }

--- a/components/providers/AppBridgeProvider.jsx
+++ b/components/providers/AppBridgeProvider.jsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { Provider } from "@shopify/app-bridge-react";
 import { Banner, Layout, Page } from "@shopify/polaris";
+import { NavigationMenu, Provider } from "@shopify/app-bridge-react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { useMemo, useState } from "react";
 
 /**
  * A component to configure App Bridge.
@@ -12,7 +12,7 @@ import { Banner, Layout, Page } from "@shopify/polaris";
  *
  * See: https://shopify.dev/apps/tools/app-bridge/getting-started/using-react
  */
-export function AppBridgeProvider({ children }) {
+export function AppBridgeProvider() {
   const location = useLocation();
   const navigate = useNavigate();
   const history = useMemo(
@@ -86,7 +86,16 @@ export function AppBridgeProvider({ children }) {
 
   return (
     <Provider config={appBridgeConfig} router={routerConfig}>
-      {children}
+      <Outlet />
+
+      <NavigationMenu
+        navigationLinks={[
+          {
+            label: "Page name",
+            destination: "/pagename",
+          },
+        ]}
+      />
     </Provider>
   );
 }

--- a/components/providers/AppRouterProvider.jsx
+++ b/components/providers/AppRouterProvider.jsx
@@ -15,7 +15,7 @@ import ErrorBoundary from "../../components/ErrorBoundary";
  * @return {RouterProvider} `<RouterProvider/>` from React Router, with a `<Route/>` for each file in `pages`
  */
 
-export function AppRouterProvider () {
+export function AppRouterProvider() {
   // Any .tsx or .jsx files in /pages will become a route
   // See https://vitejs.dev/guide/features.html#glob-import
   const pages = import.meta.globEager('../../pages/**/!(*.test.[jt]sx)*.([jt]sx)');

--- a/components/providers/index.js
+++ b/components/providers/index.js
@@ -1,3 +1,4 @@
 export { AppBridgeProvider } from "./AppBridgeProvider";
+export { AppRouterProvider } from "./AppRouterProvider";
 export { QueryProvider } from "./QueryProvider";
 export { PolarisProvider } from "./PolarisProvider";

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-query": "^3.34.19",
-    "react-router-dom": "^6.3.0",
+    "react-router-dom": "^6.9.0",
     "vite": "^2.8.6"
   },
   "devDependencies": {

--- a/pages/pagename.jsx
+++ b/pages/pagename.jsx
@@ -1,4 +1,4 @@
-import { Card, Page, Layout, TextContainer, Text } from "@shopify/polaris";
+import { Card, Layout, Page, Text, TextContainer } from "@shopify/polaris";
 import { TitleBar } from "@shopify/app-bridge-react";
 
 export default function PageName() {
@@ -38,7 +38,7 @@ export default function PageName() {
         </Layout.Section>
         <Layout.Section secondary>
           <Card sectioned>
-            <Heading>Heading</Heading>
+            <Text variant="headingMd" as="h2">Heading</Text>
             <TextContainer>
               <p>Body</p>
             </TextContainer>


### PR DESCRIPTION
### WHY are these changes introduced?

Using the latest, recommended router `createBrowserRouter`
  - These [new routers](https://reactrouter.com/en/main/routers/picking-a-router) were introduced in v6.4 and support new data apis
  - With the new data apis devs could possibly ditch react-query as there is a lot of overlap (I personally like react-query but at least we have a choice now) 
  - The real, more selfish reason I needed the new router was for the `useBlocker` hook released in v6.7.0. 
  See: https://github.com/remix-run/react-router/issues/8139#issuecomment-1396078490
  


### WHAT is this pull request doing?
- `Routes.jsx` -> `AppRouterProvider.jsx`, where all route related code is now contained
- Move `<NavigationMenu>` to `AppBridgeProvider.jsx` which is a "layout route" that wraps all other routes
- Significantly cleans up `App.jsx`
- Add general `ErrorBoundary` error element 
- Fixes missing `<Header>` in `pagename.jsx` _(That I found thanks to the new ErrorBoundary)_
