### PR TITLE
Add `react-i18next` to front end app template

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { NavigationMenu } from "@shopify/app-bridge-react";
 import Routes from "./Routes";
 
@@ -12,6 +13,7 @@ export default function App() {
   // Any .tsx or .jsx files in /pages will become a route
   // See documentation for <Routes /> for more info
   const pages = import.meta.globEager("./pages/**/!(*.test.[jt]sx)*.([jt]sx)");
+  const { t } = useTranslation();
 
   return (
     <PolarisProvider>
@@ -21,7 +23,7 @@ export default function App() {
             <NavigationMenu
               navigationLinks={[
                 {
-                  label: "Page name",
+                  label: t("NavigationMenu.pageName"),
                   destination: "/pagename",
                 },
               ]}

--- a/components/ProductsCard.jsx
+++ b/components/ProductsCard.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Card, TextContainer, Text } from "@shopify/polaris";
 import { Toast } from "@shopify/app-bridge-react";
+import { useTranslation } from "react-i18next";
 import { useAppQuery, useAuthenticatedFetch } from "../hooks";
 
 export function ProductsCard() {
@@ -8,6 +9,8 @@ export function ProductsCard() {
   const [isLoading, setIsLoading] = useState(true);
   const [toastProps, setToastProps] = useState(emptyToastProps);
   const fetch = useAuthenticatedFetch();
+  const { t } = useTranslation();
+  const productsCount = 5;
 
   const {
     data,
@@ -33,11 +36,15 @@ export function ProductsCard() {
 
     if (response.ok) {
       await refetchProductCount();
-      setToastProps({ content: "5 products created!" });
+      setToastProps({
+        content: t("ProductsCard.productsCreatedToast", {
+          count: productsCount,
+        }),
+      });
     } else {
       setIsLoading(false);
       setToastProps({
-        content: "There was an error creating products",
+        content: t("ProductsCard.errorCreatingProductsToast"),
         error: true,
       });
     }
@@ -47,21 +54,20 @@ export function ProductsCard() {
     <>
       {toastMarkup}
       <Card
-        title="Product Counter"
+        title={t("ProductsCard.title")}
         sectioned
         primaryFooterAction={{
-          content: "Populate 5 products",
+          content: t("ProductsCard.populateProductsButton", {
+            count: productsCount,
+          }),
           onAction: handlePopulate,
           loading: isLoading,
         }}
       >
         <TextContainer spacing="loose">
-          <p>
-            Sample products are created with a default title and price. You can
-            remove them at any time.
-          </p>
+          <p>{t("ProductsCard.description")}</p>
           <Text as="h4" variant="headingMd">
-            TOTAL PRODUCTS
+            {t("ProductsCard.totalProductsHeading")}
             <Text variant="bodyMd" as="p" fontWeight="semibold">
               {isLoadingCount ? "-" : data.count}
             </Text>

--- a/components/providers/PolarisProvider.jsx
+++ b/components/providers/PolarisProvider.jsx
@@ -1,8 +1,8 @@
 import { useCallback } from "react";
 import { AppProvider } from "@shopify/polaris";
 import { useNavigate } from "@shopify/app-bridge-react";
-import translations from "@shopify/polaris/locales/en.json";
 import "@shopify/polaris/build/esm/styles.css";
+import { getPolarisTranslations } from "../../utils/i18nUtils";
 
 function AppBridgeLink({ url, children, external, ...rest }) {
   const navigate = useNavigate();
@@ -48,6 +48,8 @@ function AppBridgeLink({ url, children, external, ...rest }) {
  *
  */
 export function PolarisProvider({ children }) {
+  const translations = getPolarisTranslations();
+
   return (
     <AppProvider i18n={translations} linkComponent={AppBridgeLink}>
       {children}

--- a/index.jsx
+++ b/index.jsx
@@ -1,5 +1,9 @@
 import ReactDOM from "react-dom";
 
 import App from "./App";
+import { initI18n } from "./utils/i18nUtils";
 
-ReactDOM.render(<App />, document.getElementById("app"));
+// Ensure that locales are loaded before rendering the app
+initI18n().then(() => {
+  ReactDOM.render(<App />, document.getElementById("app"));
+});

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,38 @@
+{
+  "HomePage": {
+    "heading": "Gute Arbeit beim Erstellen einer Shopify-App 🎉",
+    "learnMore": "Erhalte mehr Informationen zum Ausbau deiner App in <ShopifyTutorialLink>diesem Shopify-Tutorial</ShopifyTutorialLink> 📚",
+    "startPopulatingYourApp": "Bist du bereit? Stelle in deiner App einige Beispielprodukte bereit, um sie in deinem Shop anzuzeigen und zu testen.",
+    "title": "App-Name",
+    "trophyAltText": "Gute Arbeit beim Erstellen einer Shopify-App",
+    "yourAppIsReadyToExplore": "Deine App kann nun erkundet werden! Sie enthält alles, was du brauchst, um loszulegen: das <PolarisLink>Polaris Designsystem</PolarisLink>, die <AdminApiLink>Shopify Admin API</AdminApiLink> und die <AppBridgeLink>App Bridge</AppBridgeLink>-UI-Bibliothek sowie entsprechende Komponenten."
+  },
+  "NavigationMenu": {
+    "pageName": "Seitenname"
+  },
+  "NotFound": {
+    "description": "Überprüfe die URL und versuche es erneut. Alternativ kannst du die Suchleiste verwenden, um zu finden, was du suchst.",
+    "heading": "Unter dieser Adresse gibt es keine Seite"
+  },
+  "PageName": {
+    "body": "Nachricht",
+    "heading": "Überschrift",
+    "primaryAction": "Primäre Aktion",
+    "secondaryAction": "Sekundäre Aktion",
+    "title": "Seitenname"
+  },
+  "ProductsCard": {
+    "description": "Beispielprodukte werden mit einem Standardtitel und -preis erstellt. Du kannst sie jederzeit entfernen.",
+    "errorCreatingProductsToast": "Beim Erstellen von Produkten ist ein Fehler aufgetreten",
+    "populateProductsButton": {
+      "one": "{{count}} Produkt bereitstellen",
+      "other": "{{count}} Produkte bereitstellen"
+    },
+    "productsCreatedToast": {
+      "one": "{{count}} Produkt erstellt!",
+      "other": "{{count}} Produkte erstellt!"
+    },
+    "title": "Produktzähler",
+    "totalProductsHeading": "PRODUKTE INSGESAMT"
+  }
+}

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -1,0 +1,38 @@
+{
+  "HomePage": {
+    "heading": "Nice work on building a Shopify app 🎉",
+    "learnMore": "Learn more about building out your app in <ShopifyTutorialLink>this Shopify tutorial</ShopifyTutorialLink> 📚",
+    "startPopulatingYourApp": "Ready to go? Start populating your app with some sample products to view and test in your store.",
+    "title": "App name",
+    "trophyAltText": "Nice work on building a Shopify app",
+    "yourAppIsReadyToExplore": "Your app is ready to explore! It contains everything you need to get started including the <PolarisLink>Polaris design system</PolarisLink>, <AdminApiLink>Shopify Admin API</AdminApiLink>, and <AppBridgeLink>App Bridge</AppBridgeLink> UI library and components."
+  },
+  "NavigationMenu": {
+    "pageName": "Page name"
+  },
+  "NotFound": {
+    "description": "Check the URL and try again, or use the search bar to find what you need.",
+    "heading": "There is no page at this address"
+  },
+  "PageName": {
+    "body": "Body",
+    "heading": "Heading",
+    "primaryAction": "Primary action",
+    "secondaryAction": "Secondary action",
+    "title": "Page name"
+  },
+  "ProductsCard": {
+    "description": "Sample products are created with a default title and price. You can remove them at any time.",
+    "errorCreatingProductsToast": "There was an error creating products",
+    "populateProductsButton": {
+      "one": "Populate {{count}} product",
+      "other": "Populate {{count}} products"
+    },
+    "productsCreatedToast": {
+      "one": "{{count}} product created!",
+      "other": "{{count}} products created!"
+    },
+    "title": "Product Counter",
+    "totalProductsHeading": "TOTAL PRODUCTS"
+  }
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,40 @@
+{
+  "HomePage": {
+    "heading": "Bravo pour l’application Shopify que vous avez créée 🎉",
+    "learnMore": "Découvrez comment concevoir votre application dans <ShopifyTutorialLink>ce tutoriel Shopify</ShopifyTutorialLink> 📚",
+    "startPopulatingYourApp": "Vous souhaitez vous lancer ? Commencez à remplir votre application d’exemples de produits à afficher et tester dans votre boutique.",
+    "title": "Nom de l’application",
+    "trophyAltText": "Bravo pour l’application Shopify que vous avez créée",
+    "yourAppIsReadyToExplore": "Votre application est prête à être explorée ! Elle contient tout ce dont vous avez besoin pour vous lancer, y compris le <PolarisLink>système de design Polaris</PolarisLink>, la <AdminApiLink>Shopify Admin API</AdminApiLink> ainsi que la bibliothèque et les composants d’IU <AppBridgeLink>App Bridge</AppBridgeLink>."
+  },
+  "NavigationMenu": {
+    "pageName": "Nom de la page"
+  },
+  "NotFound": {
+    "description": "Vérifiez l’URL et réessayez, ou utilisez la barre de recherche pour trouver ce qu’il vous faut.",
+    "heading": "Il n’y a aucune page à cette adresse"
+  },
+  "PageName": {
+    "body": "Corps",
+    "heading": "En-tête",
+    "primaryAction": "Action principale",
+    "secondaryAction": "Action secondaire",
+    "title": "Nom de la page"
+  },
+  "ProductsCard": {
+    "description": "Les exemples de produits sont créés avec un titre et un prix par défaut. Vous pouvez les supprimer à tout moment.",
+    "errorCreatingProductsToast": "Une erreur est survenue lors de la création des produits",
+    "populateProductsButton": {
+      "one": "Remplir {{count}} produit",
+      "other": "Remplir {{count}} produits",
+      "many": "Remplir {{count}} produits"
+    },
+    "productsCreatedToast": {
+      "one": "{{count}} produit créé !",
+      "other": "{{count}} produits créés !",
+      "many": "{{count}} produits créés !"
+    },
+    "title": "Compteur de produits",
+    "totalProductsHeading": "TOTAL DES PRODUITS"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,22 +16,29 @@
     "extends": "@shopify/stylelint-polaris"
   },
   "dependencies": {
+    "@formatjs/intl-locale": "^3.1.1",
+    "@formatjs/intl-localematcher": "^0.2.32",
+    "@formatjs/intl-pluralrules": "^5.2.2",
     "@shopify/app-bridge": "^3.7.7",
     "@shopify/app-bridge-react": "^3.7.7",
+    "@shopify/i18next-shopify": "0.1.1",
     "@shopify/polaris": "^10.49.1",
     "@vitejs/plugin-react": "1.2.0",
+    "i18next": "^22.4.11",
+    "i18next-resources-to-backend": "^1.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-i18next": "^12.2.0",
     "react-query": "^3.34.19",
     "react-router-dom": "^6.3.0",
     "vite": "^2.8.6"
   },
   "devDependencies": {
+    "@shopify/stylelint-polaris": "^12.0.0",
     "history": "^5.3.0",
     "jsdom": "^19.0.0",
     "prettier": "^2.6.0",
-    "vi-fetch": "^0.6.1",
-    "@shopify/stylelint-polaris": "^12.0.0",
-    "stylelint": "^15.6.1"
+    "stylelint": "^15.6.1",
+    "vi-fetch": "^0.6.1"
   }
 }

--- a/pages/NotFound.jsx
+++ b/pages/NotFound.jsx
@@ -1,19 +1,15 @@
 import { Card, EmptyState, Page } from "@shopify/polaris";
+import { useTranslation } from "react-i18next";
 import { notFoundImage } from "../assets";
 
 export default function NotFound() {
+  const { t } = useTranslation();
   return (
     <Page>
       <Card>
         <Card.Section>
-          <EmptyState
-            heading="There is no page at this address"
-            image={notFoundImage}
-          >
-            <p>
-              Check the URL and try again, or use the search bar to find what
-              you need.
-            </p>
+          <EmptyState heading={t("NotFound.heading")} image={notFoundImage}>
+            <p>{t("NotFound.description")}</p>
           </EmptyState>
         </Card.Section>
       </Card>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -9,15 +9,17 @@ import {
   Text,
 } from "@shopify/polaris";
 import { TitleBar } from "@shopify/app-bridge-react";
+import { useTranslation, Trans } from "react-i18next";
 
 import { trophyImage } from "../assets";
 
 import { ProductsCard } from "../components";
 
 export default function HomePage() {
+  const { t } = useTranslation();
   return (
     <Page narrowWidth>
-      <TitleBar title="App name" primaryAction={null} />
+      <TitleBar title={t("HomePage.title")} primaryAction={null} />
       <Layout>
         <Layout.Section>
           <Card sectioned>
@@ -30,40 +32,43 @@ export default function HomePage() {
               <Stack.Item fill>
                 <TextContainer spacing="loose">
                   <Text as="h2" variant="headingMd">
-                    Nice work on building a Shopify app 🎉
+                    {t("HomePage.heading")}
                   </Text>
                   <p>
-                    Your app is ready to explore! It contains everything you
-                    need to get started including the{" "}
-                    <Link url="https://polaris.shopify.com/" external>
-                      Polaris design system
-                    </Link>
-                    ,{" "}
-                    <Link url="https://shopify.dev/api/admin-graphql" external>
-                      Shopify Admin API
-                    </Link>
-                    , and{" "}
-                    <Link
-                      url="https://shopify.dev/apps/tools/app-bridge"
-                      external
-                    >
-                      App Bridge
-                    </Link>{" "}
-                    UI library and components.
+                    <Trans
+                      i18nKey="HomePage.yourAppIsReadyToExplore"
+                      components={{
+                        PolarisLink: (
+                          <Link url="https://polaris.shopify.com/" external />
+                        ),
+                        AdminApiLink: (
+                          <Link
+                            url="https://shopify.dev/api/admin-graphql"
+                            external
+                          />
+                        ),
+                        AppBridgeLink: (
+                          <Link
+                            url="https://shopify.dev/apps/tools/app-bridge"
+                            external
+                          />
+                        ),
+                      }}
+                    />
                   </p>
+                  <p>{t("HomePage.startPopulatingYourApp")}</p>
                   <p>
-                    Ready to go? Start populating your app with some sample
-                    products to view and test in your store.{" "}
-                  </p>
-                  <p>
-                    Learn more about building out your app in{" "}
-                    <Link
-                      url="https://shopify.dev/apps/getting-started/add-functionality"
-                      external
-                    >
-                      this Shopify tutorial
-                    </Link>{" "}
-                    📚{" "}
+                    <Trans
+                      i18nKey="HomePage.learnMore"
+                      components={{
+                        ShopifyTutorialLink: (
+                          <Link
+                            url="https://shopify.dev/apps/getting-started/add-functionality"
+                            external
+                          />
+                        ),
+                      }}
+                    />
                   </p>
                 </TextContainer>
               </Stack.Item>
@@ -71,7 +76,7 @@ export default function HomePage() {
                 <div style={{ padding: "0 20px" }}>
                   <Image
                     source={trophyImage}
-                    alt="Nice work on building a Shopify app"
+                    alt={t("HomePage.trophyAltText")}
                     width={120}
                   />
                 </div>

--- a/pages/pagename.jsx
+++ b/pages/pagename.jsx
@@ -1,18 +1,20 @@
 import { Card, Page, Layout, TextContainer, Text } from "@shopify/polaris";
 import { TitleBar } from "@shopify/app-bridge-react";
+import { useTranslation } from "react-i18next";
 
 export default function PageName() {
+  const { t } = useTranslation();
   return (
     <Page>
       <TitleBar
-        title="Page name"
+        title={t("PageName.title")}
         primaryAction={{
-          content: "Primary action",
+          content: t("PageName.primaryAction"),
           onAction: () => console.log("Primary action"),
         }}
         secondaryActions={[
           {
-            content: "Secondary action",
+            content: t("PageName.secondaryAction"),
             onAction: () => console.log("Secondary action"),
           },
         ]}
@@ -21,28 +23,28 @@ export default function PageName() {
         <Layout.Section>
           <Card sectioned>
             <Text variant="headingMd" as="h2">
-              Heading
+              {t("PageName.heading")}
             </Text>
             <TextContainer>
-              <p>Body</p>
+              <p>{t("PageName.body")}</p>
             </TextContainer>
           </Card>
           <Card sectioned>
             <Text variant="headingMd" as="h2">
-              Heading
+              {t("PageName.heading")}
             </Text>
             <TextContainer>
-              <p>Body</p>
+              <p>{t("PageName.body")}</p>
             </TextContainer>
           </Card>
         </Layout.Section>
         <Layout.Section secondary>
           <Card sectioned>
             <Text variant="headingMd" as="h2">
-              Heading
+              {t("PageName.heading")}
             </Text>
             <TextContainer>
-              <p>Body</p>
+              <p>{t("PageName.body")}</p>
             </TextContainer>
           </Card>
         </Layout.Section>

--- a/utils/i18nUtils.js
+++ b/utils/i18nUtils.js
@@ -1,0 +1,184 @@
+import i18next from "i18next";
+import { initReactI18next } from "react-i18next";
+import ShopifyFormat from "@shopify/i18next-shopify";
+import resourcesToBackend from "i18next-resources-to-backend";
+import { match } from "@formatjs/intl-localematcher";
+import { shouldPolyfill as shouldPolyfillLocale } from "@formatjs/intl-locale/should-polyfill";
+import { shouldPolyfill as shouldPolyfillPluralRules } from "@formatjs/intl-pluralrules/should-polyfill";
+import {
+  DEFAULT_LOCALE as DEFAULT_POLARIS_LOCALE,
+  SUPPORTED_LOCALES as SUPPORTED_POLARIS_LOCALES,
+} from "@shopify/polaris";
+
+/**
+ * The default locale for the app.
+ *
+ * This should correspond with the JSON file in the `locales` folder with the naming convention `{locale}.default.json`.
+ * @example
+ *   en.default.json
+ */
+const DEFAULT_APP_LOCALE = "en";
+
+/**
+ * The supported locales for the app.
+ *
+ * These should correspond with the JSON files in the `locales` folder.
+ *
+ * @example
+ *   en.default.json
+ *   de.json
+ *   fr.json
+ * @see Available languages in the Shopify Help Center:
+ * https://help.shopify.com/en/manual/your-account/languages#available-languages
+ */
+const SUPPORTED_APP_LOCALES = ["en", "de", "fr"];
+
+let _userLocale, _polarisTranslations;
+
+/**
+ * Retrieves the user's locale from the `locale` request parameter and matches it to supported app locales.
+ *
+ * Returns the default app locale if the user locale is not supported.
+ *
+ * @see https://shopify.dev/docs/apps/best-practices/internationalization/getting-started#step-2-get-access-to-the-users-locale
+ *
+ * @returns {string} User locale
+ */
+export function getUserLocale() {
+  if (_userLocale) {
+    return _userLocale;
+  }
+  const url = new URL(window.location.href);
+  const locale = url.searchParams.get("locale") || DEFAULT_APP_LOCALE;
+  _userLocale = match([locale], SUPPORTED_APP_LOCALES, DEFAULT_APP_LOCALE);
+  return _userLocale;
+}
+
+/**
+ * Returns Polaris translations that correspond to the user locale.
+ *
+ * Returns Polaris translations for the default locale if the user locale is not supported.
+ *
+ * @see https://polaris.shopify.com/components/utilities/app-provider#using-translations
+ *
+ * @returns {TranslationDictionary} Polaris translations
+ */
+export function getPolarisTranslations() {
+  return _polarisTranslations;
+}
+
+/**
+ * @async
+ * Asynchronously initializes i18next and loads Polaris translations.
+ *
+ * Intended to be called before rendering the app to ensure translations are present.
+ */
+export async function initI18n() {
+  await loadIntlPolyfills();
+  await Promise.all([initI18next(), fetchPolarisTranslations()]);
+}
+
+/**
+ * @private
+ * @async
+ * Asynchronously loads Intl polyfills for the default locale and user locale.
+ */
+async function loadIntlPolyfills() {
+  if (shouldPolyfillLocale()) {
+    await import("@formatjs/intl-locale/polyfill");
+  }
+  const promises = [];
+  if (shouldPolyfillPluralRules(DEFAULT_APP_LOCALE)) {
+    await import("@formatjs/intl-pluralrules/polyfill-force");
+    promises.push(loadIntlPluralRulesLocaleData(DEFAULT_APP_LOCALE));
+  }
+  if (
+    DEFAULT_APP_LOCALE !== getUserLocale() &&
+    shouldPolyfillPluralRules(getUserLocale())
+  ) {
+    promises.push(loadIntlPluralRulesLocaleData(getUserLocale()));
+  }
+  await Promise.all(promises);
+}
+
+async function loadIntlPluralRulesLocaleData(locale) {
+  return (
+    await import(
+      `../node_modules/@formatjs/intl-pluralrules/locale-data/${locale}.js`
+    )
+  ).default;
+}
+
+/**
+ * @private
+ * @async
+ * Asynchronously initializes i18next.
+ * @see https://www.i18next.com/overview/configuration-options
+ * @returns Promise of initialized i18next instance
+ */
+async function initI18next() {
+  return await i18next
+    .use(initReactI18next)
+    .use(ShopifyFormat)
+    .use(localResourcesToBackend())
+    .init({
+      debug: process.env.NODE_ENV === "development",
+      lng: getUserLocale(),
+      fallbackLng: DEFAULT_APP_LOCALE,
+      supportedLngs: SUPPORTED_APP_LOCALES,
+      interpolation: {
+        // React escapes values by default
+        escapeValue: false,
+      },
+      react: {
+        // Wait for the locales to be loaded before rendering the app
+        // instead of using a Suspense component
+        useSuspense: false,
+      },
+    });
+}
+
+function localResourcesToBackend() {
+  return resourcesToBackend(async (locale, _namespace) => {
+    const fallbackLng = Array.isArray(i18next.options.fallbackLng)
+      ? i18next.options.fallbackLng[0]
+      : i18next.options.fallbackLng;
+    const defaultIndicator = locale === fallbackLng ? ".default" : "";
+    return (await import(`../locales/${locale}${defaultIndicator}.json`))
+      .default;
+  });
+}
+
+/**
+ * @private
+ * @async
+ * Asynchronously loads Polaris translations that correspond to the user locale.
+ *
+ * Loads Polaris translations for the default locale if the user locale is not supported.
+ * @returns {Promise<TranslationDictionary>} Promise of Polaris translations
+ */
+async function fetchPolarisTranslations() {
+  if (_polarisTranslations) {
+    return _polarisTranslations;
+  }
+  // Get the closest matching default locale supported by Polaris
+  const defaultPolarisLocale = match(
+    [DEFAULT_APP_LOCALE],
+    SUPPORTED_POLARIS_LOCALES,
+    DEFAULT_POLARIS_LOCALE
+  );
+  // Get the closest matching user locale supported by Polaris
+  const polarisLocale = match(
+    [getUserLocale()],
+    SUPPORTED_POLARIS_LOCALES,
+    defaultPolarisLocale
+  );
+  _polarisTranslations = await loadPolarisTranslations(polarisLocale);
+  return _polarisTranslations;
+}
+
+async function loadPolarisTranslations(locale) {
+  return (
+    await import(`../node_modules/@shopify/polaris/locales/${locale}.json`)
+  ).default;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Part of the project [App Localization - Tools and Guidance](https://vault.shopify.io/gsd/projects/32590) ([tech design](https://docs.google.com/document/d/1GXdgDr6Zwn5XQ7mWgIKNTIRxpTmpYnCwNWHIx0i9Cps/edit#heading=h.17h4tgs2zusg)).

Translating apps is technically challenging, time-consuming, and costly. Despite the high demand for localized apps internationally, only a small fraction of apps offered in the Shopify App Store are translated. 

None of Shopify's app templates are localized, meaning that the full burden of responsibility is on the developer to research and implement an i18n framework for their app. It’s also more likely to be an afterthought until the developer decides to expand internationally, at which point the effort to externalize all the app's strings is much higher.

By localizing the front end app template, we reduce the toil for developers, and set them up to localize their apps from the start.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR:
- Adds the following libraries:
  - [`i18next`](https://www.i18next.com/)
  - [`react-i18next`](https://react.i18next.com/)
  - [`i18next-resources-to-backend`](https://github.com/i18next/i18next-resources-to-backend) to dynamically import translations
  - [`@shopify/i18next-shopify`](https://github.com/Shopify/i18next-shopify) to use Shopify's translation file format
  - [`@formatjs/intl-localematcher`](https://formatjs.io/docs/polyfills/intl-localematcher/) to match preferred locales against supported locales
  - [`@formatjs/intl-locale`](https://formatjs.io/docs/polyfills/intl-locale) to polyfill [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) if necessary
  - [`@formatjs/intl-pluralrules`](https://formatjs.io/docs/polyfills/intl-pluralrules) to polyfill [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) if necessary
- Extracts all hard-coded strings into `locales/en.default.json`
- Adds `locales/fr.json` and `locales/dr.json` files for demonstration purposes
- Adds an `i18nUtils` utility to initialize `i18next` and load application and Polaris locales
- Updates `index.jsx` to initialize `i18next` and load locales before rendering React

English:
<img width="628" alt="Screenshot 2023-05-12 at 10 30 08 AM" src="https://github.com/Shopify/shopify-frontend-template-react/assets/1530553/874aefb3-5663-49b7-b419-f5fd82a04ada">

German:
<img width="629" alt="Screenshot 2023-05-12 at 10 29 32 AM" src="https://github.com/Shopify/shopify-frontend-template-react/assets/1530553/8b127ae6-842b-4f67-bb8a-f52872b3fdb9">

French:
<img width="633" alt="Screenshot 2023-05-12 at 10 29 07 AM" src="https://github.com/Shopify/shopify-frontend-template-react/assets/1530553/a753c7a2-5864-4f81-983e-54d8df516c7f">

#### Why `react-i18next`?

- It is the most popular open source React i18n framework
- It has comprehensive documentation and it's easy to get started
- It's extensible with many [plugins](https://www.i18next.com/overview/plugins-and-utils), including one for Remix

### Changes to the build assets

- The application bundle size grew from 518 / 135 KB to 587 / 159 KB - a difference of 69 / 24 KB.
- The application and Polaris locales are built separately for dynamic importing.
- The `Intl.Locale` polyfill is build separately for dynamic importing if necessary.

Before:
<img width="488" alt="Screenshot 2023-04-19 at 8 40 36 AM" src="https://user-images.githubusercontent.com/1530553/233093459-175d5cca-1916-4a03-90af-e2e5181b57f9.png">

After:
<img width="489" alt="Screenshot 2023-04-14 at 9 49 41 AM" src="https://user-images.githubusercontent.com/1530553/233093605-abd04cdb-1ed7-44d5-9747-e6838ac2e408.png">

### TODO

Update the README for each app template to describe the internationalization approach with links to more resources.

### Tophat 🎩 

Generate a new Node app with the following command:
```
yarn create @shopify/app --template https://github.com/Shopify/shopify-app-template-node#add-18next
```

After you have named your app, navigate to the app directory and run `yarn dev`.

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable