### PR TITLE
[Fix] add Promise.reject() to useAppQuery if server returned 400>=

### DIFF
--- a/hooks/useAppQuery.js
+++ b/hooks/useAppQuery.js
@@ -20,7 +20,7 @@ export const useAppQuery = ({ url, fetchInit = {}, reactQueryOptions }) => {
     return async () => {
       const response = await authenticatedFetch(url, fetchInit);
       if (!response.ok) {
-        return Promise.reject(`Error: ${response.status} ${response.statusText}`)
+        return Promise.reject(`Error: ${response.status}`)
       }
       return response.json();
     };


### PR DESCRIPTION
### WHY are these changes introduced?

If the server returns anything, useAppQuery will treat it as a success. It doesn't take into consideration the status code.
Example:

Server running express.js:
```
    if (!metafieldConfigKey?.body?.data?.shop?.metafield || !metafieldConfigSecret?.body?.data?.shop?.metafield) {
      res.status(404).send({});
      return;
    }
```

Frontend
```
    const response = useAppQuery({
        url: "/api/settings",
        reactQueryOptions: {
            onSuccess: async (response) => {
                const {
                    api_key,
                    confirmation_id,
                } = response[0];

                setValues((previousValues) => ({
                    ...previousValues,
                    api_key,
                    confirmation_id
                }));

                setIsLoading(false);
            },
            onError: async (response) => {
              console.log('error');
              setIsLoading(false);
            },
        },

    });

    console.log(response.isSuccess) // always returns true
```


### WHAT is this pull request doing?

If the response status is not ok, it will return rejected promise with an error message containing the status code. The message should be improved
