### PR TITLE
Polaris v10 - missed a <Heading>

### DIFF
--- a/pages/pagename.jsx
+++ b/pages/pagename.jsx
@@ -38,7 +38,9 @@ export default function PageName() {
         </Layout.Section>
         <Layout.Section secondary>
           <Card sectioned>
-            <Heading>Heading</Heading>
+            <Text variant="headingMd" as="h2">
+              Heading
+            </Text>
             <TextContainer>
               <p>Body</p>
             </TextContainer>


### PR DESCRIPTION
### WHY are these changes introduced?

[In an upgrade to Polaris v10](https://github.com/Shopify/shopify-frontend-template-react/pull/156), `<Heading>` components were removed. One of these headings was missed, throwing an error when loading `pagename.jsx`.

### WHAT is this pull request doing?

Replaces `<Heading>` with `<Text variant="headingMd" as="h2">`.

|  Before |  After |
|---|---|
|![image](https://user-images.githubusercontent.com/59898611/231916967-c0ab2de2-efd2-4c7e-96d4-ec458b83c3c4.png)| ![image](https://user-images.githubusercontent.com/59898611/231917603-083b9da8-b90c-44ef-acec-fed0177775d5.png)|