### PR TITLE
Allow /exitiframe to reach Shopify domains

### DIFF
--- a/pages/ExitIframe.jsx
+++ b/pages/ExitIframe.jsx
@@ -13,11 +13,18 @@ export default function ExitIframe() {
       const redirectUri = params.get("redirectUri");
       const url = new URL(decodeURIComponent(redirectUri));
 
-      if (url.hostname === location.hostname) {
+      if (
+        [location.hostname, "admin.shopify.com"].includes(url.hostname) ||
+        url.hostname.endsWith(".myshopify.com")
+      ) {
         const redirect = Redirect.create(app);
         redirect.dispatch(
           Redirect.Action.REMOTE,
           decodeURIComponent(redirectUri)
+        );
+      } else {
+        console.warn(
+          "/exitiframe redirect target is not in the app or a Shopify domain, refusing to redirect"
         );
       }
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, `/exitiframe` can only go to the app, but there are cases like for billing where apps might want to go to Shopify domains.

### WHAT is this pull request doing?

Allowing `admin.shopify.com` and `*.myshopify.com` as valid destinations.