### PR TITLE
Add React as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "@shopify/polaris": "^10.42.0",
     "@shopify/stylelint-polaris": "^9.0.2",
     "@vitejs/plugin-react": "1.2.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "react-query": "^3.34.19",
     "react-router-dom": "^6.3.0",
     "vite": "^2.8.6"
+  },
+  "peerDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
   },
   "devDependencies": {
     "history": "^5.3.0",


### PR DESCRIPTION
### WHY are these changes introduced?

We have seen some issues with React because the CLI now requires React 18, but then the app/extensions require React 17.

I'm facing this problem now when using workspaces + NPM (https://github.com/Shopify/cli/pull/1778).

### WHAT is this pull request doing?

Adds `react` and `react-dom` as peer dependencies, as [React recommends](https://react.dev/warnings/invalid-hook-call-warning#duplicate-react).

I've checked that it works with npm/yarn/pnpm, and also with/without workspaces (all the combinations).