### PR TITLE
Revert "Add React as peer dependency"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,11 @@
     "@shopify/polaris": "^10.42.0",
     "@shopify/stylelint-polaris": "^9.0.2",
     "@vitejs/plugin-react": "1.2.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-query": "^3.34.19",
     "react-router-dom": "^6.3.0",
     "vite": "^2.8.6"
-  },
-  "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
   },
   "devDependencies": {
     "history": "^5.3.0",


### PR DESCRIPTION
Reverts Shopify/shopify-frontend-template-react#190

I've realized that this change would break apps created with the current CLI when using yarn, because yarn doesn't install peer dependencies by default.

So let's revert this for now until we find a better way to solve this issue.