### PR TITLE
Use new CLI env variable names

### DIFF
--- a/components/providers/AppBridgeProvider.jsx
+++ b/components/providers/AppBridgeProvider.jsx
@@ -43,18 +43,18 @@ export function AppBridgeProvider({ children }) {
 
     return {
       host,
-      apiKey: process.env.SHOPIFY_API_KEY,
+      apiKey: process.env.SHOPIFY_APP_API_KEY,
       forceRedirect: true,
     };
   });
 
-  if (!process.env.SHOPIFY_API_KEY || !appBridgeConfig.host) {
-    const bannerProps = !process.env.SHOPIFY_API_KEY
+  if (!process.env.SHOPIFY_APP_API_KEY || !appBridgeConfig.host) {
+    const bannerProps = !process.env.SHOPIFY_APP_API_KEY
       ? {
           title: "Missing Shopify API Key",
           children: (
             <>
-              Your app is running without the SHOPIFY_API_KEY environment
+              Your app is running without the SHOPIFY_APP_API_KEY environment
               variable. Please ensure that it is set when running or building
               your React app.
             </>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,13 +4,17 @@ import { fileURLToPath } from "url";
 import https from "https";
 import react from "@vitejs/plugin-react";
 
+const SHOPIFY_APP_API_KEY =
+  process.env.SHOPIFY_APP_API_KEY || process.env.SHOPIFY_API_KEY;
+const SHOPIFY_APP_URL = process.env.SHOPIFY_APP_URL || process.env.HOST;
+
 if (
   process.env.npm_lifecycle_event === "build" &&
   !process.env.CI &&
-  !process.env.SHOPIFY_API_KEY
+  !SHOPIFY_APP_API_KEY
 ) {
   console.warn(
-    "\nBuilding the frontend app without an API key. The frontend build will not run without an API key. Set the SHOPIFY_API_KEY environment variable when running the build command.\n"
+    "\nBuilding the frontend app without an API key. The frontend build will not run without an API key. Set the SHOPIFY_APP_API_KEY environment variable when running the build command.\n"
   );
 }
 
@@ -21,8 +25,8 @@ const proxyOptions = {
   ws: false,
 };
 
-const host = process.env.HOST
-  ? process.env.HOST.replace(/https?:\/\//, "")
+const host = SHOPIFY_APP_URL
+  ? SHOPIFY_APP_URL.replace(/https?:\/\//, "")
   : "localhost";
 
 let hmrConfig;
@@ -46,7 +50,7 @@ export default defineConfig({
   root: dirname(fileURLToPath(import.meta.url)),
   plugins: [react()],
   define: {
-    "process.env.SHOPIFY_API_KEY": JSON.stringify(process.env.SHOPIFY_API_KEY),
+    "process.env.SHOPIFY_APP_API_KEY": JSON.stringify(SHOPIFY_APP_API_KEY),
   },
   resolve: {
     preserveSymlinks: true,


### PR DESCRIPTION
### WHY are these changes introduced?

With https://github.com/Shopify/cli/pull/1789, the CLI will deprecate some env var names. While they will still be present so previous apps won't break, we should migrate new apps as soon as possible to the new format.

### WHAT is this pull request doing?

Using the new env vars when available, but falling back to the current ones so apps won't break with any version of the CLI.