### PR TITLE
Upgrade Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^17.0.2",
     "react-query": "^3.34.19",
     "react-router-dom": "^6.3.0",
-    "vite": "^2.8.6"
+    "vite": "^4.3.9"
   },
   "devDependencies": {
     "history": "^5.3.0",


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1850

As explained [here](https://github.com/Shopify/cli/issues/1850#issuecomment-1564337898), there seems to be a problem with Vite 2.8.6 and Node 17/18/19.

### WHAT is this pull request doing?

Upgrades the Vite dependency to ^4.3.9.

I've tested that it works as expected in a Node Shopify app with every compatible major version of Node.
