### PR TITLE
Update merge_patch_dependencies.yml

### DIFF
--- a/.github/workflows/merge_patch_dependencies.yml
+++ b/.github/workflows/merge_patch_dependencies.yml
@@ -14,19 +14,9 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve and merge Dependabot PRs for patch versions
         if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'}}
-        uses: actions/github-script@v5
-        with:
-          script: |
-            await github.rest.pulls.createReview({
-              pull_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event: 'APPROVE',
-            })
-
-            await github.rest.pulls.merge({
-              merge_method: "merge",
-              owner: repository.owner,
-              pull_number: pullRequest.number,
-              repo: repository.repo,
-            })
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The Dependabot automerge action is not working correctly (see [error](https://github.com/Shopify/shopify-frontend-template-react/actions/runs/5129059258/jobs/9328087169?pr=217) for reference).

The problem seems to be the call to `repository.owner` and `repository.repo`.

I replaced this section to instead call `gh pr review` and `gh pr merge`, which removes the need for the `scripts` action.
