### PR TITLE
[Feature] Adding Vite manual chunks

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -48,6 +48,23 @@ export default defineConfig({
   define: {
     "process.env.SHOPIFY_API_KEY": JSON.stringify(process.env.SHOPIFY_API_KEY),
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            return 'vendor';
+          }
+          if (id.includes('/src/')) {
+            return id.split('/src/')[1].split('/')[0];
+          }
+          return 'misc';
+        },
+        chunkFileNames: "[name]-[hash].js",
+      }
+    },
+    chunkSizeWarningLimit: 500, // This is for warning, not for splitting
+  },
   resolve: {
     preserveSymlinks: true,
   },


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Manually defining the splitting can be a bit complex, especially if you have an extensive application with many dependencies. Fortunately, rollup (which Vite uses under the hood) provides the manualChunks option to allow more granular control over the chunking behavior.

For a simple configuration, you'd want to ensure each file in your src directory becomes its chunk (assuming they're larger than the threshold), and then set a maxSize for these chunks.

### WHAT is this pull request doing?

I'm adding the manualChunks function checks if a module is in node_modules and, if so, groups it into a vendor chunk. If it's in the src directory, it creates a chunk named after the first part of its path (so /src/utils/foo.js and /src/utils/bar.js would both end up in a utils chunk). Everything else goes into a misc chunk.

Note: The manualChunks logic is a simplistic approach and might not fit all use cases. It's often used as a starting point.

<img width="1262" alt="Screenshot 2023-08-23 at 8 40 22 PM" src="https://github.com/Shopify/shopify-frontend-template-react/assets/610598/0af0dc8d-8057-42e0-8219-1f3ae1a0978d">

