### PR TITLE
Update `@shopify/i18next-shopify`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@formatjs/intl-pluralrules": "^5.2.4",
     "@shopify/app-bridge": "^3.7.7",
     "@shopify/app-bridge-react": "^3.7.7",
-    "@shopify/i18next-shopify": "^0.2.3",
+    "@shopify/i18next-shopify": "^0.2.9",
     "@shopify/polaris": "^10.49.1",
     "@vitejs/plugin-react": "1.2.0",
     "i18next": "^23.1.0",


### PR DESCRIPTION
### WHY are these changes introduced?

Update `@shopify/i18next-shopify` to the latest version (0.2.9).

Version 0.2.8 was causing [production issues](https://github.com/Shopify/i18next-shopify/pull/194) - it looks like this was never installed on the front end template, but it's still a good idea to update to the latest version.