### PR TITLE
Fix stylelint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "history": "^5.3.0",
     "jsdom": "^24.0.0",
     "prettier": "^3.2.5",
-    "stylelint": "^16.6.1",
+    "stylelint": "^15.0.0",
     "vi-fetch": "^0.6.1"
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, installing the dependencies for this project fails when using `npm`, because the Polaris stylelint package depends on `stylelint` < 16, so we can't go past that version until we migrate to node 20, when polaris can be taken past v12.

### WHAT is this pull request doing?

Rolling back the `stylelint` version to one that works across the board.