### PR TITLE
Fix redirectUri with decodeURIComponent

### DIFF
--- a/pages/ExitIframe.jsx
+++ b/pages/ExitIframe.jsx
@@ -20,7 +20,7 @@ export default function ExitIframe() {
         [location.hostname, "admin.shopify.com"].includes(url.hostname) ||
         url.hostname.endsWith(".myshopify.com")
       ) {
-        window.open(decodeURIComponent(redirectUri), "_top");
+        window.open(url, "_top");
       } else {
         setShowWarning(true);
       }

--- a/pages/ExitIframe.jsx
+++ b/pages/ExitIframe.jsx
@@ -20,7 +20,7 @@ export default function ExitIframe() {
         [location.hostname, "admin.shopify.com"].includes(url.hostname) ||
         url.hostname.endsWith(".myshopify.com")
       ) {
-        window.open(redirectUri, "_top");
+        window.open(decodeURIComponent(redirectUri), "_top");
       } else {
         setShowWarning(true);
       }


### PR DESCRIPTION
Problem: retrieving a URL from a query parameter contains encoded characters (%25, %2F). When you pass redirectUri to window.open, the browser interprets the percent signs literally as part of the URL instead of decoding them back to their original characters.
Solution: use decodeURIComponent()