### PR TITLE
fix: Open links in _self when not external

### DIFF
--- a/components/providers/PolarisProvider.jsx
+++ b/components/providers/PolarisProvider.jsx
@@ -4,7 +4,7 @@ import "@shopify/polaris/build/esm/styles.css";
 import { getPolarisTranslations } from "../../utils/i18nUtils";
 
 function AppBridgeLink({ url, children, external, ...rest }) {
-  const handleClick = useCallback(() => window.open(url), [url]);
+  const handleClick = useCallback(() => window.open(url, "_self"), [url]);
 
   const IS_EXTERNAL_LINK_REGEX = /^(?:[a-z][a-z\d+.-]*:|\/\/)/;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue introduced in #255 where non-external links open in a new window.

### WHAT is this pull request doing?

This fix updates the `window.open` call to include a `target` of `_self`.
