### PR TITLE
Fix: incorrect closing tag in NavMenu Link

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -19,7 +19,7 @@ export default function App() {
         <QueryProvider>
           <NavMenu>
             <Link to="/" rel="home" />
-            <Link to="/pagename">{t("NavigationMenu.pageName")}</a>
+            <Link to="/pagename">{t("NavigationMenu.pageName")}</Link>
           </NavMenu>
           <Routes pages={pages} />
         </QueryProvider>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- Replace with issue number if one exists -->

This PR fixes a JSX syntax issue in the `NavMenu` component where a `<Link>` was incorrectly closed using an HTML `</a>` tag. This results in a rendering bug and violates proper React component structure.

### WHAT is this pull request doing?

- Fixes the closing tag for the second `<Link>` component in `NavMenu`
- Ensures the navigation renders without errors

#### Before:
```jsx
<NavMenu>
  <Link to="/" rel="home" />
  <Link to="/pagename">{t("NavigationMenu.pageName")}</a>
</NavMenu>
