### PR TITLE
Fix: Replace incorrect closing </a> tag with </Link> in NavMenu

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -19,7 +19,7 @@ export default function App() {
         <QueryProvider>
           <NavMenu>
             <Link to="/" rel="home" />
-            <Link to="/pagename">{t("NavigationMenu.pageName")}</a>
+            <Link to="/pagename">{t("NavigationMenu.pageName")}</Link>
           </NavMenu>
           <Routes pages={pages} />
         </QueryProvider>


### PR DESCRIPTION
Fix: Replace incorrect closing </a> tag with </Link> in NavMenu

### WHY are these changes introduced?

Fixes a bug where the NavMenu component had mismatched HTML tags that could cause rendering issues and break React Router functionality.

### WHAT is this pull request doing?

- Fixed incorrect closing `</a>` tag that should have been `</Link>` in the NavMenu component
- Ensures proper React Router Link component closing tag is used instead of raw HTML anchor tag
- Maintains consistency with React Router component usage throughout the navigation

This is a small but important fix that ensures the navigation menu renders correctly and maintains proper React component structure.