### PR TITLE
fix: correct closing tag for Link component in NavMenu

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -19,7 +19,7 @@ export default function App() {
         <QueryProvider>
           <NavMenu>
             <Link to="/" rel="home" />
-            <Link to="/pagename">{t("NavigationMenu.pageName")}</a>
+            <Link to="/pagename">{t("NavigationMenu.pageName")}</Link>
           </NavMenu>
           <Routes pages={pages} />
         </QueryProvider>


### PR DESCRIPTION
## Fix: Correct Link component closing tag in App.jsx

### WHY are these changes introduced?

Fixes incorrect JSX syntax where a `<Link>` component was being closed with an HTML `</a>` tag instead of the proper `</Link>` tag. This was causing potential rendering issues and violates React component syntax rules.

### WHAT is this pull request doing?

- Changed the closing tag from `</a>` to `</Link>` for the home navigation link in the NavMenu component
- Ensures proper JSX syntax consistency throughout the navigation structure
- Maintains React Router's Link component integrity